### PR TITLE
fix(reforma): envolve gIBSCBSMono em gMonoPadrao conforme NT 2025.002-RTC [DEV-1953]

### DIFF
--- a/docs/reforma_tributaria.md
+++ b/docs/reforma_tributaria.md
@@ -43,15 +43,27 @@ A implementacao cobre:
 
 ### Tributacao monofasica — `gIBSCBSMono`
 
-Para produtos com CST 620 (combustiveis, etc.) o grupo emitido dentro de `<IBSCBS>` e `<gIBSCBSMono>` ao inves de `<gIBSCBS>`. Campos obrigatorios:
+Para produtos com CST 620 (combustiveis, etc.) o grupo emitido dentro de `<IBSCBS>` e `<gIBSCBSMono>` ao inves de `<gIBSCBS>`. Conforme o schema oficial (`DFeTiposBasicos_v1.00.xsd`, type `TMonofasia`), os cinco campos monofasicos vivem sob o wrapper obrigatorio `<gMonoPadrao>` e na ordem definida pelo schema:
+
+```xml
+<gIBSCBSMono>
+  <gMonoPadrao>
+    <qBCMono>18.0000</qBCMono>
+    <adRemIBS>0.1000</adRemIBS>
+    <adRemCBS>0.0000</adRemCBS>
+    <vIBSMono>1.80</vIBSMono>
+    <vCBSMono>0.00</vCBSMono>
+  </gMonoPadrao>
+</gIBSCBSMono>
+```
 
 | Campo | Tipo | Descricao |
 |-------|------|-----------|
-| `qBCMono` | TDec_1104v | Quantidade tributada na base monofasica |
-| `adRemIBS` | TDec_0302a10 | Aliquota ad rem IBS (valor em BRL por unidade) |
-| `vIBSMono` | TDec_1302 | Valor IBS monofasico |
-| `adRemCBS` | TDec_0302a10 | Aliquota ad rem CBS (valor em BRL por unidade) |
-| `vCBSMono` | TDec_1302 | Valor CBS monofasico |
+| `qBCMono` | TDec1104RTC | Quantidade tributada na base monofasica |
+| `adRemIBS` | TDec_0302_04RTC | Aliquota ad rem IBS (valor em BRL por unidade) |
+| `adRemCBS` | TDec_0302_04RTC | Aliquota ad rem CBS (valor em BRL por unidade) |
+| `vIBSMono` | TDec1302RTC | Valor IBS monofasico |
+| `vCBSMono` | TDec1302RTC | Valor CBS monofasico |
 
 Atributos na entidade `NotaFiscalProduto`: `ibscbs_q_bc_mono`, `ibscbs_ad_rem_ibs`, `ibscbs_v_ibs_mono`, `ibscbs_ad_rem_cbs`, `ibscbs_v_cbs_mono`.
 

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1397,29 +1397,46 @@ class SerializacaoXML(Serializacao):
     def _serializar_gibscbs_mono(self, produto_servico, ibscbs):
         """Serializa <gIBSCBSMono> para CSTs monofasicas (620).
 
-        Estrutura obrigatoria por NT 2025.002-RTC:
+        Estrutura obrigatoria por NT 2025.002-RTC (type TMonofasia do
+        DFeTiposBasicos_v1.00.xsd, sequencia gMonoPadrao -> gMonoReten ->
+        gMonoRet -> gMonoDif). Para CST 620 "Tributacao monofasica padrao"
+        emitimos apenas <gMonoPadrao> com os cinco campos na ordem do
+        schema:
+
             <gIBSCBSMono>
-                <qBCMono>TDec_1104v (4 casas)</qBCMono>
-                <adRemIBS>TDec_0302a10 (4 casas)</adRemIBS>
-                <vIBSMono>TDec_1302 (2 casas)</vIBSMono>
-                <adRemCBS>TDec_0302a10 (4 casas)</adRemCBS>
-                <vCBSMono>TDec_1302 (2 casas)</vCBSMono>
+                <gMonoPadrao>
+                    <qBCMono>TDec1104RTC (4 casas)</qBCMono>
+                    <adRemIBS>TDec_0302_04RTC (4 casas)</adRemIBS>
+                    <adRemCBS>TDec_0302_04RTC (4 casas)</adRemCBS>
+                    <vIBSMono>TDec1302RTC (2 casas)</vIBSMono>
+                    <vCBSMono>TDec1302RTC (2 casas)</vCBSMono>
+                </gMonoPadrao>
             </gIBSCBSMono>
+
+        IMPORTANT:
+        - O wrapper <gMonoPadrao> e obrigatorio. Antes desta correcao o
+          grupo era emitido flat (sem o wrapper) e SEFAZ rejeitava com
+          cStat 225 "Falha no Schema XML da NFe (Elemento:
+          enviNFe/NFe[1]/infNFe/det[1]/imposto/IBSCBS/gIBSCBSMono/qBCMono)".
+        - A ordem <adRemCBS> antes de <vIBSMono> segue o schema oficial
+          (linhas 701-725 de DFeTiposBasicos_v1.00.xsd). A ordem anterior
+          (<vIBSMono> antes de <adRemCBS>) tambem violava o schema.
         """
         gibscbs_mono = etree.SubElement(ibscbs, "gIBSCBSMono")
-        etree.SubElement(gibscbs_mono, "qBCMono").text = "{:.4f}".format(
+        gmono_padrao = etree.SubElement(gibscbs_mono, "gMonoPadrao")
+        etree.SubElement(gmono_padrao, "qBCMono").text = "{:.4f}".format(
             produto_servico.ibscbs_q_bc_mono or 0
         )
-        etree.SubElement(gibscbs_mono, "adRemIBS").text = "{:.4f}".format(
+        etree.SubElement(gmono_padrao, "adRemIBS").text = "{:.4f}".format(
             produto_servico.ibscbs_ad_rem_ibs or 0
         )
-        etree.SubElement(gibscbs_mono, "vIBSMono").text = "{:.2f}".format(
-            produto_servico.ibscbs_v_ibs_mono or 0
-        )
-        etree.SubElement(gibscbs_mono, "adRemCBS").text = "{:.4f}".format(
+        etree.SubElement(gmono_padrao, "adRemCBS").text = "{:.4f}".format(
             produto_servico.ibscbs_ad_rem_cbs or 0
         )
-        etree.SubElement(gibscbs_mono, "vCBSMono").text = "{:.2f}".format(
+        etree.SubElement(gmono_padrao, "vIBSMono").text = "{:.2f}".format(
+            produto_servico.ibscbs_v_ibs_mono or 0
+        )
+        etree.SubElement(gmono_padrao, "vCBSMono").text = "{:.2f}".format(
             produto_servico.ibscbs_v_cbs_mono or 0
         )
 

--- a/tests/test_nfe_serializacao_reforma_tributaria.py
+++ b/tests/test_nfe_serializacao_reforma_tributaria.py
@@ -713,36 +713,41 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
         cclass = xml.xpath("//ns:IBSCBS/ns:cClassTrib", namespaces=self.ns)[0].text
         self.assertEqual(cclass, "620006")
 
-        # <gIBSCBSMono> is emitted
+        # <gIBSCBSMono> is emitted with <gMonoPadrao> wrapper (NT 2025.002-RTC)
         gibscbs_mono = xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono", namespaces=self.ns)
         self.assertEqual(len(gibscbs_mono), 1)
+
+        gmono_padrao = xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono/ns:gMonoPadrao", namespaces=self.ns)
+        self.assertEqual(len(gmono_padrao), 1)
 
         # <gIBSCBS> is NOT emitted (we use monophasic instead)
         gibscbs = xml.xpath("//ns:IBSCBS/ns:gIBSCBS", namespaces=self.ns)
         self.assertEqual(len(gibscbs), 0)
 
         # Verify the 5 required monophasic fields in correct order
-        q_bc_mono = xml.xpath("//ns:gIBSCBSMono/ns:qBCMono", namespaces=self.ns)[0].text
+        q_bc_mono = xml.xpath("//ns:gMonoPadrao/ns:qBCMono", namespaces=self.ns)[0].text
         self.assertEqual(q_bc_mono, "18.0000")
 
-        ad_rem_ibs = xml.xpath("//ns:gIBSCBSMono/ns:adRemIBS", namespaces=self.ns)[0].text
+        ad_rem_ibs = xml.xpath("//ns:gMonoPadrao/ns:adRemIBS", namespaces=self.ns)[0].text
         self.assertEqual(ad_rem_ibs, "0.0000")
 
-        v_ibs_mono = xml.xpath("//ns:gIBSCBSMono/ns:vIBSMono", namespaces=self.ns)[0].text
+        v_ibs_mono = xml.xpath("//ns:gMonoPadrao/ns:vIBSMono", namespaces=self.ns)[0].text
         self.assertEqual(v_ibs_mono, "0.00")
 
-        ad_rem_cbs = xml.xpath("//ns:gIBSCBSMono/ns:adRemCBS", namespaces=self.ns)[0].text
+        ad_rem_cbs = xml.xpath("//ns:gMonoPadrao/ns:adRemCBS", namespaces=self.ns)[0].text
         self.assertEqual(ad_rem_cbs, "0.0000")
 
-        v_cbs_mono = xml.xpath("//ns:gIBSCBSMono/ns:vCBSMono", namespaces=self.ns)[0].text
+        v_cbs_mono = xml.xpath("//ns:gMonoPadrao/ns:vCBSMono", namespaces=self.ns)[0].text
         self.assertEqual(v_cbs_mono, "0.00")
 
-        # Field order: qBCMono, adRemIBS, vIBSMono, adRemCBS, vCBSMono
-        mono_elem = gibscbs_mono[0]
-        field_names = [child.tag.split("}")[-1] for child in mono_elem]
+        # Field order per schema TMonofasia/gMonoPadrao:
+        # qBCMono, adRemIBS, adRemCBS, vIBSMono, vCBSMono
+        # (adRemCBS must come BEFORE vIBSMono per DFeTiposBasicos_v1.00.xsd)
+        padrao_elem = gmono_padrao[0]
+        field_names = [child.tag.split("}")[-1] for child in padrao_elem]
         self.assertEqual(
             field_names,
-            ["qBCMono", "adRemIBS", "vIBSMono", "adRemCBS", "vCBSMono"],
+            ["qBCMono", "adRemIBS", "adRemCBS", "vIBSMono", "vCBSMono"],
         )
 
     def test_cst620_monofasica_com_valores_calculados(self):
@@ -768,20 +773,21 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
 
         xml = self._serializar_e_assinar()
 
+        # Values live under <gIBSCBSMono>/<gMonoPadrao> per NT 2025.002-RTC
         self.assertEqual(
-            xml.xpath("//ns:gIBSCBSMono/ns:qBCMono", namespaces=self.ns)[0].text, "100.0000"
+            xml.xpath("//ns:gMonoPadrao/ns:qBCMono", namespaces=self.ns)[0].text, "100.0000"
         )
         self.assertEqual(
-            xml.xpath("//ns:gIBSCBSMono/ns:adRemIBS", namespaces=self.ns)[0].text, "0.1500"
+            xml.xpath("//ns:gMonoPadrao/ns:adRemIBS", namespaces=self.ns)[0].text, "0.1500"
         )
         self.assertEqual(
-            xml.xpath("//ns:gIBSCBSMono/ns:vIBSMono", namespaces=self.ns)[0].text, "15.00"
+            xml.xpath("//ns:gMonoPadrao/ns:vIBSMono", namespaces=self.ns)[0].text, "15.00"
         )
         self.assertEqual(
-            xml.xpath("//ns:gIBSCBSMono/ns:adRemCBS", namespaces=self.ns)[0].text, "0.8500"
+            xml.xpath("//ns:gMonoPadrao/ns:adRemCBS", namespaces=self.ns)[0].text, "0.8500"
         )
         self.assertEqual(
-            xml.xpath("//ns:gIBSCBSMono/ns:vCBSMono", namespaces=self.ns)[0].text, "85.00"
+            xml.xpath("//ns:gMonoPadrao/ns:vCBSMono", namespaces=self.ns)[0].text, "85.00"
         )
 
     def test_cst000_nao_emite_gibscbsmono_regressao(self):


### PR DESCRIPTION
## Summary

Corrige a serializacao do grupo `<gIBSCBSMono>` (tributacao monofasica IBS/CBS, CST 620) conforme o schema oficial da NT 2025.002-RTC (`DFeTiposBasicos_v1.00.xsd`, type `TMonofasia`).

Problema: os cinco campos monofasicos eram emitidos direto dentro de `<gIBSCBSMono>`, sem o wrapper `<gMonoPadrao>` exigido pelo schema. Alem disso, a ordem dos campos estava errada (`adRemCBS` deve vir antes de `vIBSMono`).

SEFAZ rejeita toda emissao com cStat 225:

> Falha no Schema XML da NFe
> Elemento: `enviNFe/NFe[1]/infNFe/det[1]/imposto/IBSCBS/gIBSCBSMono/qBCMono`

## Estrutura corrigida

Antes:

```xml
<gIBSCBSMono>
  <qBCMono>18.0000</qBCMono>
  <adRemIBS>0.1000</adRemIBS>
  <vIBSMono>1.80</vIBSMono>      <!-- ordem errada -->
  <adRemCBS>0.0000</adRemCBS>    <!-- ordem errada -->
  <vCBSMono>0.00</vCBSMono>
</gIBSCBSMono>
```

Depois:

```xml
<gIBSCBSMono>
  <gMonoPadrao>
    <qBCMono>18.0000</qBCMono>
    <adRemIBS>0.1000</adRemIBS>
    <adRemCBS>0.0000</adRemCBS>
    <vIBSMono>1.80</vIBSMono>
    <vCBSMono>0.00</vCBSMono>
  </gMonoPadrao>
</gIBSCBSMono>
```

Referencia: `DFeTiposBasicos_v1.00.xsd` linhas 687-727 (`TMonofasia` / `gMonoPadrao`).

## Test plan

- [x] `pytest tests/test_nfe_serializacao_reforma_tributaria.py` — 13 passed
- [x] Tests atualizados para validar wrapper `<gMonoPadrao>` e ordem dos campos
- [ ] Validar emissao real em ambiente de homologacao SEFAZ apos merge

## Issue

DEV-1953 — [rejeicao SEFAZ cStat 225 em 579 NF-e de devolucao GLP](https://linear.app/nuvel/issue/DEV-1953)

PR no repo API consumidor: a abrir apos este merge.
