### PR TITLE
fix(reforma): adiciona vTotIBSMonoItem e vTotCBSMonoItem em gIBSCBSMono [DEV-1954]

### DIFF
--- a/docs/reforma_tributaria.md
+++ b/docs/reforma_tributaria.md
@@ -43,7 +43,7 @@ A implementacao cobre:
 
 ### Tributacao monofasica — `gIBSCBSMono`
 
-Para produtos com CST 620 (combustiveis, etc.) o grupo emitido dentro de `<IBSCBS>` e `<gIBSCBSMono>` ao inves de `<gIBSCBS>`. Conforme o schema oficial (`DFeTiposBasicos_v1.00.xsd`, type `TMonofasia`), os cinco campos monofasicos vivem sob o wrapper obrigatorio `<gMonoPadrao>` e na ordem definida pelo schema:
+Para produtos com CST 620 (combustiveis, etc.) o grupo emitido dentro de `<IBSCBS>` e `<gIBSCBSMono>` ao inves de `<gIBSCBS>`. Conforme o schema oficial (`DFeTiposBasicos_v1.00.xsd`, type `TMonofasia`), os cinco campos monofasicos vivem sob o wrapper obrigatorio `<gMonoPadrao>` e na ordem definida pelo schema. Alem disso, `<vTotIBSMonoItem>` e `<vTotCBSMonoItem>` sao SIBLINGS de `<gMonoPadrao>` (NAO filhos) e ambos sao OBRIGATORIOS por schema (sem `minOccurs=0`):
 
 ```xml
 <gIBSCBSMono>
@@ -54,6 +54,8 @@ Para produtos com CST 620 (combustiveis, etc.) o grupo emitido dentro de `<IBSCB
     <vIBSMono>1.80</vIBSMono>
     <vCBSMono>0.00</vCBSMono>
   </gMonoPadrao>
+  <vTotIBSMonoItem>1.80</vTotIBSMonoItem>
+  <vTotCBSMonoItem>0.00</vTotCBSMonoItem>
 </gIBSCBSMono>
 ```
 
@@ -64,8 +66,12 @@ Para produtos com CST 620 (combustiveis, etc.) o grupo emitido dentro de `<IBSCB
 | `adRemCBS` | TDec_0302_04RTC | Aliquota ad rem CBS (valor em BRL por unidade) |
 | `vIBSMono` | TDec1302RTC | Valor IBS monofasico |
 | `vCBSMono` | TDec1302RTC | Valor CBS monofasico |
+| `vTotIBSMonoItem` | TDec1302RTC | Total IBS monofasico do item (sibling de `gMonoPadrao`) |
+| `vTotCBSMonoItem` | TDec1302RTC | Total CBS monofasico do item (sibling de `gMonoPadrao`) |
 
-Atributos na entidade `NotaFiscalProduto`: `ibscbs_q_bc_mono`, `ibscbs_ad_rem_ibs`, `ibscbs_v_ibs_mono`, `ibscbs_ad_rem_cbs`, `ibscbs_v_cbs_mono`.
+Atributos na entidade `NotaFiscalProduto`: `ibscbs_q_bc_mono`, `ibscbs_ad_rem_ibs`, `ibscbs_v_ibs_mono`, `ibscbs_ad_rem_cbs`, `ibscbs_v_cbs_mono`, `ibscbs_v_tot_ibs_mono_item`, `ibscbs_v_tot_cbs_mono_item`.
+
+Para itens single-line (sem retencao / retencao anterior / diferimento), `vTotIBSMonoItem == vIBSMono` e `vTotCBSMonoItem == vCBSMono`. Quando os atributos nao sao informados pelo caller, o serializador emite `0.00` (default seguro durante o Teste de Carga 2026 com ad rem zerados).
 
 Durante o Teste de Carga 2026 os ad rem ainda nao foram publicados pela SEFAZ, entao os valores podem ser zerados — o grupo `gIBSCBSMono` ainda sera emitido corretamente.
 

--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -1051,11 +1051,17 @@ class NotaFiscalProduto(Entidade):
     # qBCMono = quantity in monophasic base unit (TDec_1104v)
     # adRemIBS / adRemCBS = ad rem rate in BRL per unit (TDec_0302a10)
     # vIBSMono / vCBSMono = final value in BRL
+    # vTotIBSMonoItem / vTotCBSMonoItem = item-level mono totals (TDec1302RTC). Per
+    # NT 2025.002-RTC schema TMonofasia, these are REQUIRED siblings of
+    # <gMonoPadrao> inside <gIBSCBSMono> (NOT children of <gMonoPadrao>). For a
+    # single-line item without retencao/diferimento, they equal vIBSMono/vCBSMono.
     ibscbs_q_bc_mono = Decimal()  # qBCMono
     ibscbs_ad_rem_ibs = Decimal()  # adRemIBS
     ibscbs_v_ibs_mono = Decimal()  # vIBSMono
     ibscbs_ad_rem_cbs = Decimal()  # adRemCBS
     ibscbs_v_cbs_mono = Decimal()  # vCBSMono
+    ibscbs_v_tot_ibs_mono_item = Decimal()  # vTotIBSMonoItem
+    ibscbs_v_tot_cbs_mono_item = Decimal()  # vTotCBSMonoItem
 
     # IS (Imposto Seletivo) - Group UB-IS
     is_cst_selec = str()  # CSTSelec (2-digit)

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1399,9 +1399,10 @@ class SerializacaoXML(Serializacao):
 
         Estrutura obrigatoria por NT 2025.002-RTC (type TMonofasia do
         DFeTiposBasicos_v1.00.xsd, sequencia gMonoPadrao -> gMonoReten ->
-        gMonoRet -> gMonoDif). Para CST 620 "Tributacao monofasica padrao"
-        emitimos apenas <gMonoPadrao> com os cinco campos na ordem do
-        schema:
+        gMonoRet -> gMonoDif -> vTotIBSMonoItem -> vTotCBSMonoItem). Para
+        CST 620 "Tributacao monofasica padrao" emitimos apenas <gMonoPadrao>
+        com os cinco campos na ordem do schema, seguido pelos dois totais
+        item-level que sao REQUERIDOS pelo schema (sem minOccurs=0):
 
             <gIBSCBSMono>
                 <gMonoPadrao>
@@ -1411,16 +1412,22 @@ class SerializacaoXML(Serializacao):
                     <vIBSMono>TDec1302RTC (2 casas)</vIBSMono>
                     <vCBSMono>TDec1302RTC (2 casas)</vCBSMono>
                 </gMonoPadrao>
+                <vTotIBSMonoItem>TDec1302RTC (2 casas)</vTotIBSMonoItem>
+                <vTotCBSMonoItem>TDec1302RTC (2 casas)</vTotCBSMonoItem>
             </gIBSCBSMono>
 
         IMPORTANT:
-        - O wrapper <gMonoPadrao> e obrigatorio. Antes desta correcao o
-          grupo era emitido flat (sem o wrapper) e SEFAZ rejeitava com
-          cStat 225 "Falha no Schema XML da NFe (Elemento:
+        - O wrapper <gMonoPadrao> e obrigatorio. Antes da correcao da
+          DEV-1953 o grupo era emitido flat (sem o wrapper) e SEFAZ
+          rejeitava com cStat 225 "Falha no Schema XML da NFe (Elemento:
           enviNFe/NFe[1]/infNFe/det[1]/imposto/IBSCBS/gIBSCBSMono/qBCMono)".
         - A ordem <adRemCBS> antes de <vIBSMono> segue o schema oficial
           (linhas 701-725 de DFeTiposBasicos_v1.00.xsd). A ordem anterior
           (<vIBSMono> antes de <adRemCBS>) tambem violava o schema.
+        - <vTotIBSMonoItem> e <vTotCBSMonoItem> sao SIBLINGS de
+          <gMonoPadrao> (NAO filhos), ambos OBRIGATORIOS por schema (DEV-1954).
+          Sem eles SEFAZ rejeita com cStat 225 "Falha no Schema XML da NFe
+          (Elemento: ... gIBSCBSMono/)" (barra final indica fechamento).
         """
         gibscbs_mono = etree.SubElement(ibscbs, "gIBSCBSMono")
         gmono_padrao = etree.SubElement(gibscbs_mono, "gMonoPadrao")
@@ -1438,6 +1445,15 @@ class SerializacaoXML(Serializacao):
         )
         etree.SubElement(gmono_padrao, "vCBSMono").text = "{:.2f}".format(
             produto_servico.ibscbs_v_cbs_mono or 0
+        )
+        # vTotIBSMonoItem / vTotCBSMonoItem: required siblings of <gMonoPadrao>
+        # per schema TMonofasia (DEV-1954). For a single-line mono item without
+        # retencao/diferimento, these equal vIBSMono/vCBSMono.
+        etree.SubElement(gibscbs_mono, "vTotIBSMonoItem").text = "{:.2f}".format(
+            produto_servico.ibscbs_v_tot_ibs_mono_item or 0
+        )
+        etree.SubElement(gibscbs_mono, "vTotCBSMonoItem").text = "{:.2f}".format(
+            produto_servico.ibscbs_v_tot_cbs_mono_item or 0
         )
 
     def _serializar_is(self, produto_servico, tag_raiz):

--- a/tests/test_nfe_serializacao_reforma_tributaria.py
+++ b/tests/test_nfe_serializacao_reforma_tributaria.py
@@ -672,7 +672,11 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
     # ------------------------------------------------------------------
     def test_cst620_monofasica_emite_gibscbsmono(self):
         """CST 620 (tributacao monofasica) must emit <gIBSCBSMono> with
-        qBCMono, adRemIBS, vIBSMono, adRemCBS, vCBSMono — NOT <gIBSCBS>."""
+        qBCMono, adRemIBS, vIBSMono, adRemCBS, vCBSMono — NOT <gIBSCBS>.
+
+        DEV-1954: also asserts vTotIBSMonoItem / vTotCBSMonoItem siblings of
+        <gMonoPadrao> (required by schema TMonofasia).
+        """
         emitente = self._emitente()
         cliente = self._cliente()
         nf = self._nota_fiscal(emitente, cliente)
@@ -695,6 +699,9 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
             ibscbs_v_ibs_mono=Decimal("0.00"),
             ibscbs_ad_rem_cbs=Decimal("0.0000"),
             ibscbs_v_cbs_mono=Decimal("0.00"),
+            # Item-level totals (DEV-1954) - required siblings of <gMonoPadrao>
+            ibscbs_v_tot_ibs_mono_item=Decimal("0.00"),
+            ibscbs_v_tot_cbs_mono_item=Decimal("0.00"),
         )
         nf.adicionar_produto_servico(**kwargs)
         nf.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=1332.72, ind_pag=0)
@@ -750,8 +757,37 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
             ["qBCMono", "adRemIBS", "adRemCBS", "vIBSMono", "vCBSMono"],
         )
 
+        # DEV-1954: vTotIBSMonoItem / vTotCBSMonoItem must be SIBLINGS of
+        # <gMonoPadrao> (children of <gIBSCBSMono>) — NOT children of
+        # <gMonoPadrao>. Both are REQUIRED by schema TMonofasia.
+        v_tot_ibs = xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono/ns:vTotIBSMonoItem", namespaces=self.ns)
+        self.assertEqual(len(v_tot_ibs), 1)
+        self.assertEqual(v_tot_ibs[0].text, "0.00")
+        v_tot_cbs = xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono/ns:vTotCBSMonoItem", namespaces=self.ns)
+        self.assertEqual(len(v_tot_cbs), 1)
+        self.assertEqual(v_tot_cbs[0].text, "0.00")
+
+        # Totals must NOT be children of <gMonoPadrao> (common misreading of schema)
+        wrong_v_tot_ibs = xml.xpath("//ns:gMonoPadrao/ns:vTotIBSMonoItem", namespaces=self.ns)
+        self.assertEqual(len(wrong_v_tot_ibs), 0)
+        wrong_v_tot_cbs = xml.xpath("//ns:gMonoPadrao/ns:vTotCBSMonoItem", namespaces=self.ns)
+        self.assertEqual(len(wrong_v_tot_cbs), 0)
+
+        # Direct children of <gIBSCBSMono> must be in schema order:
+        # gMonoPadrao -> vTotIBSMonoItem -> vTotCBSMonoItem
+        gibscbs_mono_elem = gibscbs_mono[0]
+        direct_children = [child.tag.split("}")[-1] for child in gibscbs_mono_elem]
+        self.assertEqual(
+            direct_children,
+            ["gMonoPadrao", "vTotIBSMonoItem", "vTotCBSMonoItem"],
+        )
+
     def test_cst620_monofasica_com_valores_calculados(self):
-        """CST 620 with non-zero ad rem rates produces non-zero monophasic values."""
+        """CST 620 with non-zero ad rem rates produces non-zero monophasic values.
+
+        DEV-1954: For a single-line item without retencao/diferimento,
+        vTotIBSMonoItem == vIBSMono and vTotCBSMonoItem == vCBSMono.
+        """
         emitente = self._emitente()
         cliente = self._cliente()
         nf = self._nota_fiscal(emitente, cliente)
@@ -767,6 +803,9 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
             ibscbs_v_ibs_mono=Decimal("15.00"),
             ibscbs_ad_rem_cbs=Decimal("0.8500"),
             ibscbs_v_cbs_mono=Decimal("85.00"),
+            # Item-level totals equal the mono values for single-line items
+            ibscbs_v_tot_ibs_mono_item=Decimal("15.00"),
+            ibscbs_v_tot_cbs_mono_item=Decimal("85.00"),
         )
         nf.adicionar_produto_servico(**kwargs)
         nf.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=1000.00, ind_pag=0)
@@ -789,6 +828,52 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
         self.assertEqual(
             xml.xpath("//ns:gMonoPadrao/ns:vCBSMono", namespaces=self.ns)[0].text, "85.00"
         )
+        # DEV-1954: item-level totals equal the mono values for single-line items
+        self.assertEqual(
+            xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono/ns:vTotIBSMonoItem", namespaces=self.ns)[0].text,
+            "15.00",
+        )
+        self.assertEqual(
+            xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono/ns:vTotCBSMonoItem", namespaces=self.ns)[0].text,
+            "85.00",
+        )
+
+    def test_cst620_v_tot_mono_item_default_zero_when_unset(self):
+        """DEV-1954: vTotIBSMonoItem / vTotCBSMonoItem default to 0.00 when not provided.
+
+        Both are REQUIRED by schema TMonofasia (no minOccurs=0). Falling back
+        to 0 keeps the XML schema-valid even when callers forget to set them.
+        """
+        emitente = self._emitente()
+        cliente = self._cliente()
+        nf = self._nota_fiscal(emitente, cliente)
+
+        kwargs = self._base_product_kwargs()
+        kwargs.update(
+            codigo="012",
+            descricao="Combustivel monofasico sem totais explicitos",
+            ibscbs_cst="620",
+            ibscbs_c_class_trib="620006",
+            ibscbs_q_bc_mono=Decimal("18.0000"),
+            ibscbs_ad_rem_ibs=Decimal("0.0000"),
+            ibscbs_v_ibs_mono=Decimal("0.00"),
+            ibscbs_ad_rem_cbs=Decimal("0.0000"),
+            ibscbs_v_cbs_mono=Decimal("0.00"),
+            # NOTE: ibscbs_v_tot_ibs_mono_item / ibscbs_v_tot_cbs_mono_item NOT set
+        )
+        nf.adicionar_produto_servico(**kwargs)
+        nf.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=1332.72, ind_pag=0)
+
+        xml = self._serializar_e_assinar()
+
+        # Both totals MUST be emitted as direct children of <gIBSCBSMono>
+        # with the schema-required default of 0.00.
+        v_tot_ibs = xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono/ns:vTotIBSMonoItem", namespaces=self.ns)
+        self.assertEqual(len(v_tot_ibs), 1)
+        self.assertEqual(v_tot_ibs[0].text, "0.00")
+        v_tot_cbs = xml.xpath("//ns:IBSCBS/ns:gIBSCBSMono/ns:vTotCBSMonoItem", namespaces=self.ns)
+        self.assertEqual(len(v_tot_cbs), 1)
+        self.assertEqual(v_tot_cbs[0].text, "0.00")
 
     def test_cst000_nao_emite_gibscbsmono_regressao(self):
         """Regression test: CST 000 (regular taxation) must still emit <gIBSCBS>


### PR DESCRIPTION
## Resumo

Adiciona as tags `<vTotIBSMonoItem>` e `<vTotCBSMonoItem>` (ambas `TDec1302RTC`, REQUERIDAS sem `minOccurs=0`) como siblings de `<gMonoPadrao>` dentro de `<gIBSCBSMono>`, conforme exige o type `TMonofasia` do schema oficial NT 2025.002-RTC (`DFeTiposBasicos_v1.00.xsd`, linhas 825-836).

Sem essas duas tags, mesmo apos o fix da DEV-1953 (wrapper `<gMonoPadrao>`), o XML continuava sendo rejeitado pela SEFAZ com `cStat 225` "Falha no Schema XML da NFe (Elemento: ... `gIBSCBSMono/`)" — a barra final no caminho indica que o problema e no fechamento do grupo, nao em um filho especifico, exatamente o sintoma de campos obrigatorios ausentes no final da sequencia.

Cliente impactado em prod: `E B DA FONSECA COMERCIO DE GAS` (CNPJ 24712859000191), notas 575-581 da loja 37 todas rejeitadas mesmo apos o deploy do fix da DEV-1953.

## Schema oficial

```xml
<xs:complexType name="TMonofasia">
  <xs:sequence>
    <xs:element name="gMonoPadrao" minOccurs="0">...</xs:element>
    <xs:element name="gMonoReten"  minOccurs="0">...</xs:element>
    <xs:element name="gMonoRet"    minOccurs="0">...</xs:element>
    <xs:element name="gMonoDif"    minOccurs="0">...</xs:element>
    <xs:element name="vTotIBSMonoItem" type="TDec1302RTC"/>  <!-- REQUIRED -->
    <xs:element name="vTotCBSMonoItem" type="TDec1302RTC"/>  <!-- REQUIRED -->
  </xs:sequence>
</xs:complexType>
```

## XML antes / depois

**Antes (rejeitado):**
```xml
<gIBSCBSMono>
  <gMonoPadrao>
    <qBCMono>18.0000</qBCMono>
    <adRemIBS>0.0000</adRemIBS>
    <adRemCBS>0.0000</adRemCBS>
    <vIBSMono>0.00</vIBSMono>
    <vCBSMono>0.00</vCBSMono>
  </gMonoPadrao>
  <!-- FALTANDO: vTotIBSMonoItem -->
  <!-- FALTANDO: vTotCBSMonoItem -->
</gIBSCBSMono>
```

**Depois (aprovado pelo schema):**
```xml
<gIBSCBSMono>
  <gMonoPadrao>
    <qBCMono>18.0000</qBCMono>
    <adRemIBS>0.0000</adRemIBS>
    <adRemCBS>0.0000</adRemCBS>
    <vIBSMono>0.00</vIBSMono>
    <vCBSMono>0.00</vCBSMono>
  </gMonoPadrao>
  <vTotIBSMonoItem>0.00</vTotIBSMonoItem>
  <vTotCBSMonoItem>0.00</vTotCBSMonoItem>
</gIBSCBSMono>
```

## Mudancas

- `pynfe/entidades/notafiscal.py`: dois novos atributos `ibscbs_v_tot_ibs_mono_item` e `ibscbs_v_tot_cbs_mono_item` (default `Decimal()`) na classe `NotaFiscalProduto`. Aceitos via `kwargs` em `adicionar_produto_servico` (`Entidade.__setattr__` exige declaracao previa na classe).
- `pynfe/processamento/serializacao.py`: `_serializar_gibscbs_mono` agora emite os dois totais como filhos diretos de `<gIBSCBSMono>` apos `<gMonoPadrao>`, formatados em 2 casas decimais. Para itens single-line (sem retencao/diferimento) os totais devem igualar `vIBSMono`/`vCBSMono`. Quando nao informados pelo caller, emite `0.00` (default seguro).
- `tests/test_nfe_serializacao_reforma_tributaria.py`: estende `test_cst620_monofasica_emite_gibscbsmono` (agora valida ordem direct-children `[gMonoPadrao, vTotIBSMonoItem, vTotCBSMonoItem]` + verifica que os totais NAO sao filhos de `<gMonoPadrao>` por engano), e `test_cst620_monofasica_com_valores_calculados`. Adiciona `test_cst620_v_tot_mono_item_default_zero_when_unset` cobrindo o default `0.00`.
- `docs/reforma_tributaria.md`: exemplo XML e tabela de campos atualizados.

## Validacao

- 14/14 tests reforma tributaria passando
- 149/149 tests da suite completa passando (`python -m pytest tests/`)
- `ruff check` e `ruff format --check` clean

## Issues

- DEV-1954 (Linear) — NF-e gIBSCBSMono invalido, vTotIBSMonoItem/vTotCBSMonoItem ausentes
- Depende: DEV-1953 (PR #3, ja merged) — wrapper gMonoPadrao
