### PR TITLE
fix(reforma): adiciona gMono em IBSCBSTot para itens monofasicos [DEV-1955]

### DIFF
--- a/docs/reforma_tributaria.md
+++ b/docs/reforma_tributaria.md
@@ -335,13 +335,22 @@ Os totais ficam em um grupo **separado** de `<ICMSTot>`, como irmao dentro de `<
       <vCredPres>0.00</vCredPres>
       <vCredPresCondSus>0.00</vCredPresCondSus>
     </gCBS>
-    <!-- gMono: totais monofasia (nao implementado) -->
+    <gMono>                                <!-- Totais monofasia (DEV-1955) -->
+      <vIBSMono>0.00</vIBSMono>            <!-- Total IBS monofasico padrao -->
+      <vCBSMono>0.00</vCBSMono>            <!-- Total CBS monofasica padrao -->
+      <vIBSMonoReten>0.00</vIBSMonoReten>  <!-- Total IBS monofasico sujeito a retencao -->
+      <vCBSMonoReten>0.00</vCBSMonoReten>  <!-- Total CBS monofasica sujeita a retencao -->
+      <vIBSMonoRet>0.00</vIBSMonoRet>      <!-- Total IBS monofasico retido anteriormente -->
+      <vCBSMonoRet>0.00</vCBSMonoRet>      <!-- Total CBS monofasica retida anteriormente -->
+    </gMono>
     <!-- gEstornoCred: totais estorno de credito (nao implementado) -->
   </IBSCBSTot>
 </total>
 ```
 
 > Os subgrupos `gIBS` e `gCBS` sao opcionais (`minOccurs="0"`) — emitidos apenas quando ha valores. Os campos `vDif`, `vDevTrib`, `vCredPres` e `vCredPresCondSus` sao obrigatorios dentro de cada subgrupo (emitidos como "0.00" quando nao utilizados).
+>
+> O subgrupo `gMono` e opcional, mas obrigatorio sempre que algum item da NF-e carregar `<gIBSCBSMono>` (CST 620, etc.). Quando emitido, **todos os seis filhos** sao obrigatorios (`vIBSMono`, `vCBSMono`, `vIBSMonoReten`, `vCBSMonoReten`, `vIBSMonoRet`, `vCBSMonoRet`). Omitir `<gMono>` em uma NF-e com items monofasicos faz a SEFAZ rejeitar com `cStat 1119 - "Total de IBS e CBS nao informado"`. Os totais `Reten`/`Ret` ainda nao sao acumulados a nivel de item (PyNFe ainda so emite `<gMonoPadrao>`), entao serao "0.00" ate que `<gMonoReten>` / `<gMonoRet>` / `<gMonoDif>` sejam suportados a nivel de item.
 
 ### Cabecalho — `cMunFGIBS` no `<ide>`
 
@@ -373,7 +382,7 @@ Esses CSTs geram apenas `<CST>` e `<cClassTrib>`, sem `<gIBSCBS>`.
 
 - **`cClassTrib`**: Emitido quando informado (campo obrigatorio na pratica)
 - **`cMunFGIBS`**: Emitido no `<ide>` apenas quando informado
-- **`<IBSCBSTot>`**: Tipo `TIBSCBSMonoTot`. Omitido se todos os totais forem zero. Quando emitido, `vBCIBSCBS` e obrigatorio como primeiro filho; `gIBS` e `gCBS` sao opcionais
+- **`<IBSCBSTot>`**: Tipo `TIBSCBSMonoTot`. Omitido se todos os totais forem zero E nenhum item carregar `<gIBSCBSMono>`. Quando emitido, `vBCIBSCBS` e obrigatorio como primeiro filho; `gIBS`, `gCBS` e `gMono` sao opcionais (mas `gMono` e obrigatorio sempre que houver items monofasicos)
 - **`<IBSCBS>`**: Tipo `TTribNFe`. Omitido completamente se `ibscbs_cst` nao for informado
 - **IS (`<IS>`)**: Tipo `TIS`. **Nao emitido no XML** — serializacao desabilitada ate 2027
 - **`<ISTot>`**: Tipo `TISTot`. **Nao emitido** — sera irmao de `<IBSCBSTot>` (antes dele no schema)

--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -10,6 +10,12 @@ from pynfe.utils.flags import CODIGOS_ESTADOS, NF_STATUS
 
 from .base import CampoDeprecated, Entidade
 
+# CSTs IBS/CBS that route to <gIBSCBSMono> instead of <gIBSCBS>. Mirrors
+# the constant in pynfe.processamento.serializacao but defined here so the
+# NotaFiscal accumulator can detect monofasic items without importing the
+# serializer. Keep in sync with SerializacaoXML._IBSCBS_CST_MONOFASICO.
+_IBSCBS_CST_MONOFASICO = ("620",)
+
 
 class NotaFiscal(Entidade):
     # campos deprecados
@@ -310,6 +316,24 @@ class NotaFiscal(Entidade):
     totais_cbs = Decimal()
     totais_is = Decimal()
 
+    # Reforma Tributaria - Totais Monofasia (Group W03 - IBSCBSTot/gMono)
+    # Per NT 2025.002-RTC schema TIBSCBSMonoTot, when ANY item carries
+    # <gIBSCBSMono>, the IBSCBSTot wrapper MUST emit a <gMono> sibling with
+    # six TDec1302RTC values (all REQUIRED inside <gMono>): vIBSMono,
+    # vCBSMono, vIBSMonoReten, vCBSMonoReten, vIBSMonoRet, vCBSMonoRet.
+    # SEFAZ rejects with cStat 1119 ("Total de IBS e CBS nao informado")
+    # when items emit <gIBSCBSMono> but the totalizer omits <gMono>.
+    # ``totais_mono_item_count`` tracks the number of monofasic items so
+    # the serializer can decide to emit <gMono> even when all six values
+    # are zero (Teste de Carga 2026 scenario, where every ad rem is 0).
+    totais_v_ibs_mono = Decimal()  # sum of vTotIBSMonoItem (gMonoPadrao)
+    totais_v_cbs_mono = Decimal()  # sum of vTotCBSMonoItem (gMonoPadrao)
+    totais_v_ibs_mono_reten = Decimal()  # sum of vTotIBSMonoItem (gMonoReten)
+    totais_v_cbs_mono_reten = Decimal()  # sum of vTotCBSMonoItem (gMonoReten)
+    totais_v_ibs_mono_ret = Decimal()  # sum of vTotIBSMonoItem (gMonoRet)
+    totais_v_cbs_mono_ret = Decimal()  # sum of vTotCBSMonoItem (gMonoRet)
+    totais_mono_item_count = int()
+
     # Reforma Tributaria - cMunFGIBS (Group B)
     municipio_fato_gerador_ibs = str()
 
@@ -482,6 +506,21 @@ class NotaFiscal(Entidade):
         self.totais_ibs += obj.ibscbs_v_ibs
         self.totais_cbs += obj.ibscbs_v_cbs
         self.totais_is += obj.is_valor
+
+        # Reforma Tributaria - Totais Monofasia (IBSCBSTot/gMono per NT 2025.002-RTC)
+        # Aggregate item-level vTotIBSMonoItem / vTotCBSMonoItem so the
+        # serializer can emit <gMono> with the required totals. PyNFe today
+        # only supports <gMonoPadrao> at item level (see _serializar_gibscbs_mono),
+        # so the Reten/Ret accumulators stay at zero — but the schema requires
+        # all six fields to be emitted whenever <gMono> is present, so they
+        # are kept here to align with TIBSCBSMonoTot/gMono.
+        # ``totais_mono_item_count`` is incremented when CST routes to mono,
+        # giving the serializer a stable signal to emit <gMono> even if every
+        # value is zero (Teste de Carga 2026 scenario).
+        self.totais_v_ibs_mono += obj.ibscbs_v_tot_ibs_mono_item
+        self.totais_v_cbs_mono += obj.ibscbs_v_tot_cbs_mono_item
+        if obj.ibscbs_cst in _IBSCBS_CST_MONOFASICO:
+            self.totais_mono_item_count += 1
 
         # TODO calcular impostos aproximados
         # self.totais_tributos_aproximado += obj.tributos

--- a/pynfe/entidades/notafiscal.py
+++ b/pynfe/entidades/notafiscal.py
@@ -511,7 +511,7 @@ class NotaFiscal(Entidade):
         # Aggregate item-level vTotIBSMonoItem / vTotCBSMonoItem so the
         # serializer can emit <gMono> with the required totals. PyNFe today
         # only supports <gMonoPadrao> at item level (see _serializar_gibscbs_mono),
-        # so the Reten/Ret accumulators stay at zero — but the schema requires
+        # so the Reten/Ret accumulators stay at zero, but the schema requires
         # all six fields to be emitted whenever <gMono> is present, so they
         # are kept here to align with TIBSCBSMonoTot/gMono.
         # ``totais_mono_item_count`` is incremented when CST routes to mono,

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1875,8 +1875,17 @@ class SerializacaoXML(Serializacao):
 
         # Reforma Tributaria - Totais IVA Dual (Group W03 - IBSCBSTot)
         # Type: TIBSCBSMonoTot (PL 010b DFeTiposBasicos_v1.00.xsd)
+        # ``has_mono`` is true when at least one item routed to <gIBSCBSMono>:
+        # SEFAZ rejects with cStat 1119 ("Total de IBS e CBS nao informado")
+        # when items emit monofasia but the IBSCBSTot/gMono total is missing.
+        # During Teste de Carga 2026, every ad rem is zero so the regular
+        # accumulators stay at 0 — the count flag forces emission anyway.
+        has_mono = nota_fiscal.totais_mono_item_count > 0
         has_reforma = (
-            nota_fiscal.totais_vbc_ibscbs or nota_fiscal.totais_ibs or nota_fiscal.totais_cbs
+            nota_fiscal.totais_vbc_ibscbs
+            or nota_fiscal.totais_ibs
+            or nota_fiscal.totais_cbs
+            or has_mono
         )
         if has_reforma:
             ibscbs_tot = etree.SubElement(total, "IBSCBSTot")
@@ -1915,7 +1924,35 @@ class SerializacaoXML(Serializacao):
                 etree.SubElement(g_cbs, "vCredPres").text = "0.00"
                 etree.SubElement(g_cbs, "vCredPresCondSus").text = "0.00"
 
-            # gMono: not implemented yet (monofasia totals)
+            # gMono — totals da monofasia (DEV-1955)
+            # Per NT 2025.002-RTC schema TIBSCBSMonoTot, the <gMono> wrapper is
+            # itself optional (minOccurs=0) but, when present, ALL six children
+            # are REQUIRED (no minOccurs=0 inside). SEFAZ requires <gMono>
+            # whenever the NF-e contains items with <gIBSCBSMono>; omitting it
+            # raises cStat 1119 ("Total de IBS e CBS nao informado"). For the
+            # Teste de Carga 2026 scenario every value is "0.00", but the
+            # block itself must still be emitted.
+            if has_mono:
+                g_mono = etree.SubElement(ibscbs_tot, "gMono")
+                etree.SubElement(g_mono, "vIBSMono").text = "{:.2f}".format(
+                    nota_fiscal.totais_v_ibs_mono
+                )
+                etree.SubElement(g_mono, "vCBSMono").text = "{:.2f}".format(
+                    nota_fiscal.totais_v_cbs_mono
+                )
+                etree.SubElement(g_mono, "vIBSMonoReten").text = "{:.2f}".format(
+                    nota_fiscal.totais_v_ibs_mono_reten
+                )
+                etree.SubElement(g_mono, "vCBSMonoReten").text = "{:.2f}".format(
+                    nota_fiscal.totais_v_cbs_mono_reten
+                )
+                etree.SubElement(g_mono, "vIBSMonoRet").text = "{:.2f}".format(
+                    nota_fiscal.totais_v_ibs_mono_ret
+                )
+                etree.SubElement(g_mono, "vCBSMonoRet").text = "{:.2f}".format(
+                    nota_fiscal.totais_v_cbs_mono_ret
+                )
+
             # gEstornoCred: not implemented yet (estorno de credito totals)
 
         # Transporte

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -1879,7 +1879,7 @@ class SerializacaoXML(Serializacao):
         # SEFAZ rejects with cStat 1119 ("Total de IBS e CBS nao informado")
         # when items emit monofasia but the IBSCBSTot/gMono total is missing.
         # During Teste de Carga 2026, every ad rem is zero so the regular
-        # accumulators stay at 0 — the count flag forces emission anyway.
+        # accumulators stay at 0; the count flag forces emission anyway.
         has_mono = nota_fiscal.totais_mono_item_count > 0
         has_reforma = (
             nota_fiscal.totais_vbc_ibscbs
@@ -1924,7 +1924,7 @@ class SerializacaoXML(Serializacao):
                 etree.SubElement(g_cbs, "vCredPres").text = "0.00"
                 etree.SubElement(g_cbs, "vCredPresCondSus").text = "0.00"
 
-            # gMono — totals da monofasia (DEV-1955)
+            # gMono - totals da monofasia (DEV-1955)
             # Per NT 2025.002-RTC schema TIBSCBSMonoTot, the <gMono> wrapper is
             # itself optional (minOccurs=0) but, when present, ALL six children
             # are REQUIRED (no minOccurs=0 inside). SEFAZ requires <gMono>

--- a/tests/test_nfe_serializacao_reforma_tributaria.py
+++ b/tests/test_nfe_serializacao_reforma_tributaria.py
@@ -915,6 +915,227 @@ class ReformaTributariaSerializacaoTestCase(unittest.TestCase):
         self.assertEqual(p_cbs, "0.9000")
 
     # ------------------------------------------------------------------
+    # DEV-1955 — IBSCBSTot/<gMono> totals when items carry <gIBSCBSMono>
+    # ------------------------------------------------------------------
+    def test_ibscbstot_gmono_emitido_para_item_monofasico_unico(self):
+        """A NF-e with a single <gIBSCBSMono> item must emit IBSCBSTot/<gMono>.
+
+        Reproduces the cliente E B DA FONSECA (DEV-1955) scenario: GLP em Botijao
+        13KG, qtde 18, CST 620, cClassTrib 620006, all ad-rem zero (Teste de Carga
+        2026). Before the fix, the IBSCBSTot wrapper was suppressed entirely
+        (because totais_vbc_ibscbs / totais_ibs / totais_cbs were all 0) and
+        SEFAZ rejected with cStat 1119 "Total de IBS e CBS nao informado".
+        """
+        emitente = self._emitente()
+        cliente = self._cliente()
+        nf = self._nota_fiscal(emitente, cliente)
+
+        kwargs = self._base_product_kwargs()
+        kwargs.update(
+            codigo="020",
+            descricao="GLP em Botijao 13KG",
+            ncm="27111910",
+            quantidade_comercial=Decimal("18"),
+            valor_unitario_comercial=Decimal("74.04"),
+            valor_total_bruto=Decimal("1332.72"),
+            quantidade_tributavel=Decimal("18"),
+            valor_unitario_tributavel=Decimal("74.04"),
+            ibscbs_cst="620",
+            ibscbs_c_class_trib="620006",
+            ibscbs_q_bc_mono=Decimal("18.0000"),
+            ibscbs_ad_rem_ibs=Decimal("0.0000"),
+            ibscbs_v_ibs_mono=Decimal("0.00"),
+            ibscbs_ad_rem_cbs=Decimal("0.0000"),
+            ibscbs_v_cbs_mono=Decimal("0.00"),
+            ibscbs_v_tot_ibs_mono_item=Decimal("0.00"),
+            ibscbs_v_tot_cbs_mono_item=Decimal("0.00"),
+        )
+        nf.adicionar_produto_servico(**kwargs)
+        nf.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=1332.72, ind_pag=0)
+
+        xml = self._serializar_e_assinar()
+
+        # IBSCBSTot must be present even when standard totals are zero, because
+        # at least one item carries <gIBSCBSMono>.
+        ibscbs_tot = xml.xpath("//ns:total/ns:IBSCBSTot", namespaces=self.ns)
+        self.assertEqual(len(ibscbs_tot), 1)
+
+        # gMono inside IBSCBSTot must contain the six required TDec1302RTC fields,
+        # all "0.00" for the Teste de Carga scenario.
+        g_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono", namespaces=self.ns)
+        self.assertEqual(len(g_mono), 1)
+
+        v_ibs_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vIBSMono", namespaces=self.ns)
+        self.assertEqual(len(v_ibs_mono), 1)
+        self.assertEqual(v_ibs_mono[0].text, "0.00")
+
+        v_cbs_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vCBSMono", namespaces=self.ns)
+        self.assertEqual(v_cbs_mono[0].text, "0.00")
+
+        # Reten/Ret children are required by schema TIBSCBSMonoTot/gMono even
+        # when the items only carry <gMonoPadrao> (PyNFe item-level Reten/Ret
+        # serialization is not implemented yet — totals stay at zero).
+        v_ibs_mono_reten = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vIBSMonoReten", namespaces=self.ns)
+        self.assertEqual(v_ibs_mono_reten[0].text, "0.00")
+        v_cbs_mono_reten = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vCBSMonoReten", namespaces=self.ns)
+        self.assertEqual(v_cbs_mono_reten[0].text, "0.00")
+        v_ibs_mono_ret = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vIBSMonoRet", namespaces=self.ns)
+        self.assertEqual(v_ibs_mono_ret[0].text, "0.00")
+        v_cbs_mono_ret = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vCBSMonoRet", namespaces=self.ns)
+        self.assertEqual(v_cbs_mono_ret[0].text, "0.00")
+
+        # Field order must match TIBSCBSMonoTot/gMono per
+        # DFeTiposBasicos_v1.00.xsd: vIBSMono -> vCBSMono -> vIBSMonoReten ->
+        # vCBSMonoReten -> vIBSMonoRet -> vCBSMonoRet.
+        gmono_elem = g_mono[0]
+        gmono_children = [child.tag.split("}")[-1] for child in gmono_elem]
+        self.assertEqual(
+            gmono_children,
+            [
+                "vIBSMono",
+                "vCBSMono",
+                "vIBSMonoReten",
+                "vCBSMonoReten",
+                "vIBSMonoRet",
+                "vCBSMonoRet",
+            ],
+        )
+
+    def test_ibscbstot_gmono_soma_multiplos_itens_monofasicos(self):
+        """Two <gIBSCBSMono> items must sum into IBSCBSTot/<gMono>/<vIBSMono>."""
+        emitente = self._emitente()
+        cliente = self._cliente()
+        nf = self._nota_fiscal(emitente, cliente)
+
+        item1 = self._base_product_kwargs()
+        item1.update(
+            codigo="021",
+            descricao="Combustivel mono A",
+            ibscbs_cst="620",
+            ibscbs_c_class_trib="620001",
+            ibscbs_q_bc_mono=Decimal("100.0000"),
+            ibscbs_ad_rem_ibs=Decimal("0.1500"),
+            ibscbs_v_ibs_mono=Decimal("15.00"),
+            ibscbs_ad_rem_cbs=Decimal("0.8500"),
+            ibscbs_v_cbs_mono=Decimal("85.00"),
+            ibscbs_v_tot_ibs_mono_item=Decimal("15.00"),
+            ibscbs_v_tot_cbs_mono_item=Decimal("85.00"),
+        )
+        item2 = self._base_product_kwargs()
+        item2.update(
+            codigo="022",
+            descricao="Combustivel mono B",
+            ibscbs_cst="620",
+            ibscbs_c_class_trib="620002",
+            ibscbs_q_bc_mono=Decimal("50.0000"),
+            ibscbs_ad_rem_ibs=Decimal("0.2000"),
+            ibscbs_v_ibs_mono=Decimal("10.00"),
+            ibscbs_ad_rem_cbs=Decimal("0.4000"),
+            ibscbs_v_cbs_mono=Decimal("20.00"),
+            ibscbs_v_tot_ibs_mono_item=Decimal("10.00"),
+            ibscbs_v_tot_cbs_mono_item=Decimal("20.00"),
+        )
+        nf.adicionar_produto_servico(**item1)
+        nf.adicionar_produto_servico(**item2)
+        nf.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=2000.00, ind_pag=0)
+
+        xml = self._serializar_e_assinar()
+
+        v_ibs_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vIBSMono", namespaces=self.ns)
+        self.assertEqual(v_ibs_mono[0].text, "25.00")  # 15.00 + 10.00
+        v_cbs_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vCBSMono", namespaces=self.ns)
+        self.assertEqual(v_cbs_mono[0].text, "105.00")  # 85.00 + 20.00
+
+    def test_ibscbstot_sem_gmono_quando_so_itens_padrao(self):
+        """Pure standard NF-e (no <gIBSCBSMono> items) must NOT emit <gMono>."""
+        emitente = self._emitente()
+        cliente = self._cliente()
+        nf = self._nota_fiscal(emitente, cliente)
+
+        kwargs = self._base_product_kwargs()
+        kwargs.update(
+            ibscbs_cst="000",
+            ibscbs_c_class_trib="000001",
+            ibscbs_vbc=Decimal("1000.00"),
+            ibscbs_p_ibs_uf=Decimal("0.1000"),
+            ibscbs_v_ibs_uf=Decimal("1.00"),
+            ibscbs_p_ibs_mun=Decimal("0.0000"),
+            ibscbs_v_ibs_mun=Decimal("0.00"),
+            ibscbs_v_ibs=Decimal("1.00"),
+            ibscbs_p_cbs=Decimal("0.9000"),
+            ibscbs_v_cbs=Decimal("9.00"),
+        )
+        nf.adicionar_produto_servico(**kwargs)
+        nf.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=1000.00, ind_pag=0)
+
+        xml = self._serializar_e_assinar()
+
+        # IBSCBSTot is present (we have standard reforma values)
+        ibscbs_tot = xml.xpath("//ns:total/ns:IBSCBSTot", namespaces=self.ns)
+        self.assertEqual(len(ibscbs_tot), 1)
+        # But gMono must NOT be there for a pure-standard NF-e
+        g_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono", namespaces=self.ns)
+        self.assertEqual(len(g_mono), 0)
+
+    def test_ibscbstot_misto_emite_gibs_gcbs_e_gmono(self):
+        """Mixed NF-e (1 standard + 1 mono) emits gIBS, gCBS AND gMono."""
+        emitente = self._emitente()
+        cliente = self._cliente()
+        nf = self._nota_fiscal(emitente, cliente)
+
+        item_padrao = self._base_product_kwargs()
+        item_padrao.update(
+            codigo="030",
+            descricao="Item padrao",
+            ibscbs_cst="000",
+            ibscbs_c_class_trib="000001",
+            ibscbs_vbc=Decimal("1000.00"),
+            ibscbs_p_ibs_uf=Decimal("0.1000"),
+            ibscbs_v_ibs_uf=Decimal("1.00"),
+            ibscbs_p_ibs_mun=Decimal("0.0000"),
+            ibscbs_v_ibs_mun=Decimal("0.00"),
+            ibscbs_v_ibs=Decimal("1.00"),
+            ibscbs_p_cbs=Decimal("0.9000"),
+            ibscbs_v_cbs=Decimal("9.00"),
+        )
+        item_mono = self._base_product_kwargs()
+        item_mono.update(
+            codigo="031",
+            descricao="Item monofasico",
+            ibscbs_cst="620",
+            ibscbs_c_class_trib="620001",
+            ibscbs_q_bc_mono=Decimal("10.0000"),
+            ibscbs_ad_rem_ibs=Decimal("0.5000"),
+            ibscbs_v_ibs_mono=Decimal("5.00"),
+            ibscbs_ad_rem_cbs=Decimal("1.0000"),
+            ibscbs_v_cbs_mono=Decimal("10.00"),
+            ibscbs_v_tot_ibs_mono_item=Decimal("5.00"),
+            ibscbs_v_tot_cbs_mono_item=Decimal("10.00"),
+        )
+        nf.adicionar_produto_servico(**item_padrao)
+        nf.adicionar_produto_servico(**item_mono)
+        nf.adicionar_pagamento(t_pag="01", x_pag="Dinheiro", v_pag=2000.00, ind_pag=0)
+
+        xml = self._serializar_e_assinar()
+
+        # Standard groups present (gIBS, gCBS) AND gMono present
+        self.assertEqual(len(xml.xpath("//ns:IBSCBSTot/ns:gIBS", namespaces=self.ns)), 1)
+        self.assertEqual(len(xml.xpath("//ns:IBSCBSTot/ns:gCBS", namespaces=self.ns)), 1)
+        self.assertEqual(len(xml.xpath("//ns:IBSCBSTot/ns:gMono", namespaces=self.ns)), 1)
+
+        # gMono carries the mono item totals
+        v_ibs_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vIBSMono", namespaces=self.ns)
+        self.assertEqual(v_ibs_mono[0].text, "5.00")
+        v_cbs_mono = xml.xpath("//ns:IBSCBSTot/ns:gMono/ns:vCBSMono", namespaces=self.ns)
+        self.assertEqual(v_cbs_mono[0].text, "10.00")
+
+        # IBSCBSTot direct-child order per TIBSCBSMonoTot:
+        # vBCIBSCBS -> gIBS -> gCBS -> gMono (gEstornoCred not implemented)
+        ibscbs_tot_elem = xml.xpath("//ns:IBSCBSTot", namespaces=self.ns)[0]
+        ibscbs_tot_children = [child.tag.split("}")[-1] for child in ibscbs_tot_elem]
+        self.assertEqual(ibscbs_tot_children, ["vBCIBSCBS", "gIBS", "gCBS", "gMono"])
+
+    # ------------------------------------------------------------------
     # Test 10: cMunFGIBS NOT emitted when not set
     # ------------------------------------------------------------------
     def test_cmunfgibs_nao_emitido_quando_vazio(self):


### PR DESCRIPTION
## Contexto

Apos os fixes [DEV-1953](https://github.com/nuvelbr/PyNFe/pull/3) (wrapper `<gMonoPadrao>`) e [DEV-1954](https://github.com/nuvelbr/PyNFe/pull/4) (`<vTotIBSMonoItem>`/`<vTotCBSMonoItem>` no item), uma NF-e contendo apenas itens monofasicos passa a validacao item-level mas SEFAZ continua rejeitando com:

> **cStat 1119 — Total de IBS e CBS nao informado** (campo: `-`)

Cliente: E B DA FONSECA COMERCIO DE GAS (CNPJ 24712859000191), Nacional Gas Butano. Devolucao de GLP em Botijao 13KG (CST 620, cClassTrib 620006, ad rem zero por estar em Teste de Carga 2026).

## Root cause

O grupo `<IBSCBSTot>` (totalizador NF-e) precisa emitir o subgrupo `<gMono>` quando ha pelo menos um item com `<gIBSCBSMono>`. Sem ele, SEFAZ rejeita com cStat 1119.

Schema oficial `TIBSCBSMonoTot` (`DFeTiposBasicos_v1.00.xsd`):

```xml
<xs:complexType name="TIBSCBSMonoTot">
  <xs:sequence>
    <xs:element name="vIBSMono"      type="TDec1302RTC"/>
    <xs:element name="vCBSMono"      type="TDec1302RTC"/>
    <xs:element name="vIBSMonoReten" type="TDec1302RTC"/>
    <xs:element name="vCBSMonoReten" type="TDec1302RTC"/>
    <xs:element name="vIBSMonoRet"   type="TDec1302RTC"/>
    <xs:element name="vCBSMonoRet"   type="TDec1302RTC"/>
  </xs:sequence>
</xs:complexType>
```

Os 6 filhos sao TODOS obrigatorios quando `<gMono>` e emitido. PyNFe hoje so suporta `<gMonoPadrao>` no item, entao Reten/Ret ficam em zero — mas precisam estar presentes.

## Mudancas

- `pynfe/entidades/notafiscal.py`: adiciona constante `_IBSCBS_CST_MONOFASICO` (espelho do set definido em `SerializacaoXML`), seis acumuladores (`totais_v_ibs_mono` / `totais_v_cbs_mono` / `totais_v_*_mono_reten` / `totais_v_*_mono_ret`) e contador `totais_mono_item_count`. Em `adicionar_produto_servico`, soma `vTotIBSMonoItem` / `vTotCBSMonoItem` e incrementa o contador para CST monofasico.
- `pynfe/processamento/serializacao.py`: forca emissao de `<IBSCBSTot>` quando ha pelo menos um item monofasico (mesmo com totais standard zerados) e emite `<gMono>` com os 6 filhos quando `totais_mono_item_count > 0`.
- `tests/test_nfe_serializacao_reforma_tributaria.py`: 4 testes novos cobrindo: cenario E B DA FONSECA single item, soma multi-item, regressao standard-only sem `<gMono>`, mista emite ambos.
- `docs/reforma_tributaria.md`: atualiza exemplo IBSCBSTot e adiciona notas sobre quando o subgrupo e obrigatorio.

## Validacao

- `pytest tests/test_nfe_serializacao_reforma_tributaria.py` — 17 passed (13 baseline + 4 novos)
- `pytest` (suite completa) — 153 passed (149 baseline + 4 novos)
- `ruff check` + `ruff format --check` — clean

## Linked

- Issue: [DEV-1955](https://linear.app/nuvel/issue/DEV-1955/nf-e-rejeicao-cstat-1119-total-de-ibs-e-cbs-nao-informado-em-nota-de)
- Anteriores no thread: [PR #3 (DEV-1953)](https://github.com/nuvelbr/PyNFe/pull/3), [PR #4 (DEV-1954)](https://github.com/nuvelbr/PyNFe/pull/4)
- Consumer api PR: a abrir apos merge desta + bump do SHA squash

🤖 Generated with [Claude Code](https://claude.com/claude-code)