### PR TITLE
fix(nfce): atualiza host do QRCode de GO para nfeweb (IT 2025.003) [DEV-2177]

### DIFF
--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -273,8 +273,8 @@ NFCE = {
         "EVENTOS": "sefaz.go.gov.br/nfe/services/NFeRecepcaoEvento4?wsdl",
         "QR": "sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe?",
         "CADASTRO": "sefaz.go.gov.br/nfe/services/CadConsultaCadastro4?wsdl",
-        "HTTPS": "https://nfe.",
-        "HOMOLOGACAO": "https://homolog.",
+        "HTTPS": "https://nfeweb.",
+        "HOMOLOGACAO": "https://nfewebhomolog.",
         "URL": "sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe",
     },
     "DF": {

--- a/tests/test_nfce_qrcode_go.py
+++ b/tests/test_nfce_qrcode_go.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# *-* encoding: utf8 *-*
+"""Regression tests for the Goias (GO) NFC-e QRCode/urlChave host.
+
+Informe Tecnico 2025.003 moved the GO NFC-e consultation host from the old
+``nfe.sefaz.go.gov.br`` / ``homolog.sefaz.go.gov.br`` subdomains to
+``nfeweb.sefaz.go.gov.br`` (producao) and ``nfewebhomolog.sefaz.go.gov.br``
+(homologacao). Emitting with the old host triggers SEFAZ rejeicao 395
+("Informado QR-Code para NFC-e com formato invalido"). These tests pin both
+the ``<qrCode>`` base and the ``<urlChave>`` so the host can never silently
+regress to the rejected subdomain again. See DEV-2177.
+"""
+
+import unittest
+
+from lxml import etree
+
+from pynfe.processamento.serializacao import SerializacaoQrcode
+from pynfe.utils.flags import NAMESPACE_NFE, NAMESPACE_SIG
+
+# cUF for Goias.
+CUF_GO = "52"
+# Producao = 1, Homologacao = 2 (NFe ide/tpAmb).
+TP_AMB_PRODUCAO = "1"
+TP_AMB_HOMOLOGACAO = "2"
+
+QRCODE_HOST_PRODUCAO = "https://nfeweb.sefaz.go.gov.br/"
+QRCODE_HOST_HOMOLOGACAO = "https://nfewebhomolog.sefaz.go.gov.br/"
+
+
+class QrcodeGoNFCeTestCase(unittest.TestCase):
+    """Exercises ``SerializacaoQrcode.gerar_qrcode`` for the GO branch."""
+
+    def _build_nfe_go(self, tp_amb):
+        """Build a minimal signed-NFe etree for GO with the fields gerar_qrcode reads."""
+        chave = CUF_GO + "0" * 42  # 44-digit access key starting with cUF 52.
+        xml = (
+            f'<NFe xmlns="{NAMESPACE_NFE}">'
+            f'<infNFe Id="NFe{chave}">'
+            f"<ide>"
+            f"<cUF>{CUF_GO}</cUF>"
+            f"<dhEmi>2025-01-14T12:00:00-03:00</dhEmi>"
+            f"<tpAmb>{tp_amb}</tpAmb>"
+            f"</ide>"
+            f"<dest><CPF>12345678900</CPF></dest>"
+            f"<total><ICMSTot><vNF>10.00</vNF></ICMSTot></total>"
+            f"</infNFe>"
+            f'<Signature xmlns="{NAMESPACE_SIG}">'
+            f"<SignedInfo><Reference>"
+            f"<DigestValue>ABCDEF==</DigestValue>"
+            f"</Reference></SignedInfo>"
+            f"</Signature>"
+            f"</NFe>"
+        )
+        return etree.fromstring(xml.encode())
+
+    def _gerar(self, tp_amb):
+        nfe = self._build_nfe_go(tp_amb)
+        nfe, qrcode = SerializacaoQrcode().gerar_qrcode("000001", "CSC123", nfe, return_qr=True)
+        supl = nfe.find("infNFeSupl")
+        self.assertIsNotNone(supl, "infNFeSupl deve ser inserido")
+        url_chave = supl.find("urlChave").text
+        # qrCode esta dentro de CDATA; o valor retornado por gerar_qrcode e o mesmo texto.
+        return qrcode, url_chave
+
+    def test_qrcode_producao_usa_host_nfeweb(self):
+        qrcode, url_chave = self._gerar(TP_AMB_PRODUCAO)
+        self.assertTrue(
+            qrcode.startswith(QRCODE_HOST_PRODUCAO),
+            f"qrCode de producao deve comecar com {QRCODE_HOST_PRODUCAO}, veio: {qrcode}",
+        )
+        self.assertTrue(
+            url_chave.startswith(QRCODE_HOST_PRODUCAO),
+            f"urlChave de producao deve comecar com {QRCODE_HOST_PRODUCAO}, veio: {url_chave}",
+        )
+        # Garante que nao reverteu para o subdominio rejeitado (rejeicao 395).
+        self.assertNotIn("https://nfe.sefaz.go.gov.br", qrcode)
+        self.assertNotIn("https://nfe.sefaz.go.gov.br", url_chave)
+
+    def test_qrcode_homologacao_usa_host_nfewebhomolog(self):
+        qrcode, url_chave = self._gerar(TP_AMB_HOMOLOGACAO)
+        self.assertTrue(
+            qrcode.startswith(QRCODE_HOST_HOMOLOGACAO),
+            f"qrCode de homologacao deve comecar com {QRCODE_HOST_HOMOLOGACAO}, veio: {qrcode}",
+        )
+        self.assertTrue(
+            url_chave.startswith(QRCODE_HOST_HOMOLOGACAO),
+            f"urlChave de homologacao deve comecar com {QRCODE_HOST_HOMOLOGACAO}, veio: {url_chave}",
+        )
+        self.assertNotIn("https://homolog.sefaz.go.gov.br", qrcode)
+        self.assertNotIn("https://homolog.sefaz.go.gov.br", url_chave)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

O Informe Tecnico 2025.003 trocou o host de consulta da NFC-e de Goias. O dict `NFCE["GO"]` em `pynfe/utils/webservices.py` ainda apontava para os subdominios antigos, gerando **rejeicao 395** ("QR-Code para NFC-e com formato invalido") nas emissoes de GO em producao.

| campo | antes | depois |
|-------|-------|--------|
| `HTTPS` (producao) | `https://nfe.` | `https://nfeweb.` |
| `HOMOLOGACAO` | `https://homolog.` | `https://nfewebhomolog.` |

Resultado final das URLs:
- Producao: `https://nfeweb.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe...`
- Homologacao: `https://nfewebhomolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe...`

Os campos `QR` e `URL` ja carregavam o path correto (`/nfeweb/sites/nfce/danfeNFCe`), entao so os prefixos de host mudaram. Tanto `<qrCode>` quanto `<urlChave>` sao montados a partir desses prefixos em `SerializacaoQrcode.gerar_qrcode`, entao ambos ficam corrigidos.

A mudanca segue a convencao de subdominio-por-UF ja usada por RS/MS no mesmo dict. Sem alteracao na logica de serializacao.

## Teste

Adicionado `tests/test_nfce_qrcode_go.py` cobrindo producao e homologacao, afirmando que `<qrCode>` e `<urlChave>` comecam com os hosts novos e nunca revertem para o subdominio rejeitado. Validado que o teste falha no codigo antigo e passa com o fix.

Ref: DEV-2177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
