### PR TITLE
fix(mdfe): envio sincrono via gzip+base64 e omissao de valePed vazio [DEV-2266]

### DIFF
--- a/pynfe/processamento/comunicacao.py
+++ b/pynfe/processamento/comunicacao.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import base64
 import datetime
+import gzip
 import re
 
 import requests
@@ -876,39 +878,34 @@ class ComunicacaoMDFe(Comunicacao):
         Método para realizar autorização do manifesto
         :param manifesto: XML assinado
         :param id_lote: Id do lote - numero autoincremental gerado pelo sistema
+            (usado apenas no envio assincrono)
         :param ind_sinc: Indicador de sincrono e assincrono, 0 para assincrono, 1 para sincrono
         :return:  Uma tupla que em caso de sucesso,
             retorna xml com manifesto e protocolo de autorização.
-        Caso contrário, envia todo o soap de resposta da Sefaz para decisão do usuário.
+        Caso contrário, retorna o retMDFe parseado (quando a SEFAZ respondeu) ou a
+        resposta HTTP crua para decisão do usuário.
         """
-        # url do serviço
-        if ind_sinc == 0:
-            url = self._get_url(consulta="RECEPCAO")
-        elif ind_sinc == 1:
-            url = self._get_url(consulta="RECEPCAO_SINC")
-        else:
-            raise "ind_sinc deve ser 0=assincrono ou 1=sincrono"
+        if ind_sinc == 1:
+            return self._autorizacao_sincrona(manifesto)
+        if ind_sinc != 0:
+            raise ValueError("ind_sinc deve ser 0=assincrono ou 1=sincrono")
+
+        # Envio assincrono: lote enviMDFe para o servico MDFeRecepcao
+        url = self._get_url(consulta="RECEPCAO")
 
         # Monta XML do corpo da requisição
         raiz = etree.Element("enviMDFe", xmlns=NAMESPACE_MDFE, versao=VERSAO_MDFE)
         etree.SubElement(raiz, "idLote").text = str(
             id_lote
         )  # numero autoincremental gerado pelo sistema
-        # etree.SubElement(raiz, 'indSinc').text = str(ind_sinc)
-        # # 0 para assincrono, 1 para sincrono
         raiz.append(manifesto)
 
         # Monta XML para envio da requisição
-        if ind_sinc == 0:
-            xml = self._construir_xml_soap("MDFeRecepcao", raiz)
-        elif ind_sinc == 1:
-            xml = self._construir_xml_soap("MDFeRecepcaoSinc", raiz)
+        xml = self._construir_xml_soap("MDFeRecepcao", raiz)
 
         # Faz request no Servidor da Sefaz
         retorno = self._post(url, xml)
 
-        # Em caso de sucesso, retorna xml com o mdfe e protocolo de autorização.
-        # Caso contrário, envia todo o soap de resposta da Sefaz para decisão do usuário.
         if retorno.status_code == 200:
             # namespace
             ns = {"ns": NAMESPACE_MDFE}
@@ -919,41 +916,59 @@ class ComunicacaoMDFe(Comunicacao):
                 # em SP retorno.text apresenta erro
                 prot = etree.fromstring(retorno.content)
 
-            if ind_sinc == 1:
-                try:
-                    # Protocolo com envio OK
-                    inf_prot = prot[1][0]
-                    lote_status = inf_prot.xpath("ns:retEnviMDFe/ns:cStat", namespaces=ns)[0].text
-
-                    # Lote processado
-                    if lote_status == self._edoc_situacao_lote_processado:
-                        prot_mdfe = inf_prot.xpath("ns:retEnviMDFe/ns:protMDFe", namespaces=ns)[0]
-                        status = prot_mdfe.xpath("ns:infProt/ns:cStat", namespaces=ns)[0].text
-
-                        # autorizado uso do MDF-e
-                        # retorna xml final (protMDFe + MDFe)
-                        if status in self._edoc_situacao_ja_enviado:  # if status == '100':
-                            raiz = etree.Element(
-                                "mdfeProc", xmlns=NAMESPACE_MDFE, versao=VERSAO_MDFE
-                            )
-                            raiz.append(manifesto)
-                            raiz.append(prot_mdfe)
-                            return 0, raiz
-                except IndexError:
-                    # Protocolo com algum erro no Envio
-                    return 1, retorno, manifesto
-            else:
-                # Retorna id do protocolo para posterior consulta em caso de sucesso.
-                rec = prot[1][0]
-                status = rec.xpath("ns:retEnviMDFe/ns:cStat", namespaces=ns)[0].text
-                # Lote Recebido com Sucesso!
-                if status in (
-                    self._edoc_situacao_arquivo_recebido_com_sucesso,
-                    self._edoc_situacao_em_processamento,
-                ):
-                    nrec = rec.xpath("ns:retEnviMDFe/ns:infRec/ns:nRec", namespaces=ns)[0].text
-                    return 0, nrec, manifesto
+            # Retorna id do protocolo para posterior consulta em caso de sucesso.
+            rec = prot[1][0]
+            status = rec.xpath("ns:retEnviMDFe/ns:cStat", namespaces=ns)[0].text
+            # Lote Recebido com Sucesso!
+            if status in (
+                self._edoc_situacao_arquivo_recebido_com_sucesso,
+                self._edoc_situacao_em_processamento,
+            ):
+                nrec = rec.xpath("ns:retEnviMDFe/ns:infRec/ns:nRec", namespaces=ns)[0].text
+                return 0, nrec, manifesto
         return 1, retorno, manifesto
+
+    def _autorizacao_sincrona(self, manifesto):
+        """Envia o MDF-e para o servico sincrono MDFeRecepcaoSinc.
+
+        Conforme o MOC do MDF-e, o servico de recepcao sincrona recebe o XML
+        assinado do <MDFe> compactado com gzip e codificado em base64 como
+        conteudo texto de mdfeDadosMsg — sem o envelope <enviMDFe>/<idLote>
+        usado no envio assincrono.
+        """
+        url = self._get_url(consulta="RECEPCAO_SINC")
+
+        mdfe_compactado = base64.b64encode(gzip.compress(etree.tostring(manifesto))).decode("ascii")
+        xml = self._construir_xml_soap("MDFeRecepcaoSinc", mdfe_compactado)
+
+        retorno = self._post(url, xml, content_type=b"application/soap+xml; charset=utf-8;")
+
+        if retorno.status_code != 200:
+            return 1, retorno, manifesto
+
+        ns = {"ns": NAMESPACE_MDFE}
+        try:
+            envelope = etree.fromstring(retorno.content)
+            ret_mdfe = envelope.xpath("//ns:retMDFe", namespaces=ns)[0]
+        except (ValueError, IndexError, etree.XMLSyntaxError):
+            # Resposta nao parseavel: devolve a resposta HTTP crua
+            return 1, retorno, manifesto
+
+        # Rejeicao pode vir no nivel do retMDFe (ex.: 580, sem protMDFe)
+        # ou no nivel do protMDFe/infProt.
+        prot_mdfe_list = ret_mdfe.xpath("ns:protMDFe", namespaces=ns)
+        if prot_mdfe_list:
+            prot_mdfe = prot_mdfe_list[0]
+            status = prot_mdfe.xpath("ns:infProt/ns:cStat", namespaces=ns)
+            # autorizado uso do MDF-e: retorna xml final (MDFe + protMDFe)
+            if status and status[0].text in self._edoc_situacao_ja_enviado:
+                raiz = etree.Element("mdfeProc", xmlns=NAMESPACE_MDFE, versao=VERSAO_MDFE)
+                raiz.append(manifesto)
+                raiz.append(prot_mdfe)
+                return 0, raiz
+
+        # Devolve o retMDFe parseado para o chamador consultar cStat/xMotivo
+        return 1, ret_mdfe, manifesto
 
     def status_servico(self):
         url = self._get_url("STATUS")
@@ -1037,16 +1052,17 @@ class ComunicacaoMDFe(Comunicacao):
 
         a = etree.SubElement(body, self._envio_mensagem, xmlns=self._namespace_metodo + metodo)
 
-        # if metodo == 'MDFeRecepcaoSinc':
-        #     body_base64 = base64.b16encode(a).decode()
-
-        a.append(dados)
+        if isinstance(dados, str):
+            # payload compactado (gzip+base64) vai como texto de mdfeDadosMsg
+            a.text = dados
+        else:
+            a.append(dados)
         return raiz
 
-    def _post_header(self, soap_webservice_method=False):
+    def _post_header(self, soap_webservice_method=False, content_type=None):
         """Retorna um dicionário com os atributos para o cabeçalho da requisição HTTP"""
         header = {
-            b"content-type": b"text/xml; charset=utf-8;",
+            b"content-type": content_type or b"text/xml; charset=utf-8;",
         }
 
         # PE é a únca UF que exige SOAPAction no header
@@ -1060,7 +1076,7 @@ class ComunicacaoMDFe(Comunicacao):
 
         return header
 
-    def _post(self, url, xml):
+    def _post(self, url, xml, content_type=None):
         certificado_a1 = CertificadoA1(self.certificado)
         chave, cert = certificado_a1.separar_arquivo(self.certificado_senha, caminho=True)
         chave_cert = (cert, chave)
@@ -1084,7 +1100,7 @@ class ComunicacaoMDFe(Comunicacao):
             result = requests.post(
                 url,
                 xml,
-                headers=self._post_header(),
+                headers=self._post_header(content_type=content_type),
                 cert=chave_cert,
                 verify=False,
                 timeout=50,

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -2561,7 +2561,9 @@ class SerializacaoMDFe(Serializacao):
                     etree.SubElement(infCIOT, "CNPJ").text = item.cpfcnpj
 
         # Vale Pedágio
-        if modal_rodoviario.pedagio is not None:
+        # valePed must be omitted when there are no disp entries: an empty
+        # <valePed/> is rejected by the MDF-e modal schema (cStat 580).
+        if modal_rodoviario.pedagio:
             valePed = etree.SubElement(infANTT, "valePed")
             for num, item in enumerate(modal_rodoviario.pedagio):
                 disp = etree.SubElement(valePed, "disp")
@@ -2592,6 +2594,11 @@ class SerializacaoMDFe(Serializacao):
                     etree.SubElement(infContrato, "vContratoGlobal").text = "{:.2f}".format(
                         item.vContratoGlobal or 0
                     )
+
+        # infANTT is fully optional: omit it when no child was serialized
+        # (e.g. carga própria without RNTRC/CIOT/vale-pedágio/contratantes).
+        if len(infANTT) == 0:
+            rodo.remove(infANTT)
 
         # Veículo Tração
         if len(modal_rodoviario.veiculo_tracao) != 1:

--- a/tests/test_mdfe_comunicacao_sinc.py
+++ b/tests/test_mdfe_comunicacao_sinc.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+# *-* encoding: utf8 *-*
+"""Testes do envio sincrono do MDF-e (MDFeRecepcaoSinc) e da serializacao do valePed."""
+
+import base64
+import gzip
+import unittest
+from decimal import Decimal
+from unittest import mock
+
+from pynfe.entidades.manifesto import (
+    ManifestoCondutor,
+    ManifestoRodoviario,
+    ManifestoVeiculoTracao,
+)
+from pynfe.processamento.comunicacao import ComunicacaoMDFe
+from pynfe.processamento.serializacao import SerializacaoMDFe
+from pynfe.utils import etree
+from pynfe.utils.flags import NAMESPACE_MDFE
+
+NS = {"ns": NAMESPACE_MDFE}
+
+
+def _fake_response(status_code, text):
+    response = mock.Mock()
+    response.status_code = status_code
+    response.text = text
+    response.content = text.encode("utf-8")
+    return response
+
+
+def _soap_response(ret_mdfe_xml):
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">'
+        "<soap:Body>"
+        '<mdfeRecepcaoResult xmlns="http://www.portalfiscal.inf.br/mdfe/wsdl/MDFeRecepcaoSinc">'
+        + ret_mdfe_xml
+        + "</mdfeRecepcaoResult>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    )
+
+
+def _manifesto_assinado_fake():
+    mdfe = etree.Element("MDFe", xmlns=NAMESPACE_MDFE)
+    inf = etree.SubElement(
+        mdfe, "infMDFe", Id="MDFe51210199999999000199580009200000000011000000008"
+    )
+    etree.SubElement(inf, "ide")
+    return mdfe
+
+
+class ComunicacaoMDFeRecepcaoSincTestCase(unittest.TestCase):
+    def setUp(self):
+        self.con = ComunicacaoMDFe("rj", "certificado.pfx", "senha", homologacao=True)
+        self.manifesto = _manifesto_assinado_fake()
+
+    def test_envelope_sinc_envia_mdfe_gzip_base64_como_texto(self):
+        """O servico sincrono exige o MDFe gzip+base64 como texto de mdfeDadosMsg."""
+        with mock.patch.object(self.con, "_post") as post:
+            post.return_value = _fake_response(400, "")
+            self.con.autorizacao(self.manifesto, ind_sinc=1)
+
+        (url, envelope), kwargs = post.call_args
+        self.assertIn("RecepcaoSinc", url)
+        self.assertEqual(kwargs.get("content_type"), b"application/soap+xml; charset=utf-8;")
+
+        dados_msg = envelope.xpath("//*[local-name()='Body']/*[local-name()='mdfeDadosMsg']")[0]
+        # sem envelope enviMDFe/idLote e sem elementos filhos
+        self.assertEqual(len(dados_msg), 0)
+        payload = gzip.decompress(base64.b64decode(dados_msg.text))
+        self.assertEqual(payload, etree.tostring(self.manifesto))
+        raiz_payload = etree.fromstring(payload)
+        self.assertEqual(etree.QName(raiz_payload).localname, "MDFe")
+
+    def test_sinc_autorizado_retorna_mdfe_proc(self):
+        ret = (
+            '<retMDFe versao="3.00" xmlns="http://www.portalfiscal.inf.br/mdfe">'
+            "<tpAmb>2</tpAmb><cUF>33</cUF><cStat>104</cStat><xMotivo>Lote processado</xMotivo>"
+            '<protMDFe versao="3.00"><infProt><tpAmb>2</tpAmb><cStat>100</cStat>'
+            "<xMotivo>Autorizado o uso do MDF-e</xMotivo>"
+            "<nProt>933210000000000</nProt></infProt></protMDFe>"
+            "</retMDFe>"
+        )
+        with mock.patch.object(self.con, "_post") as post:
+            post.return_value = _fake_response(200, _soap_response(ret))
+            resultado = self.con.autorizacao(self.manifesto, ind_sinc=1)
+
+        self.assertEqual(resultado[0], 0)
+        proc = resultado[1]
+        self.assertEqual(etree.QName(proc).localname, "mdfeProc")
+        self.assertEqual(
+            proc.xpath("ns:protMDFe/ns:infProt/ns:cStat", namespaces=NS)[0].text, "100"
+        )
+        self.assertEqual(len(proc.xpath("*[local-name()='MDFe']")), 1)
+
+    def test_sinc_rejeicao_nivel_retmdfe_sem_protmdfe(self):
+        """Rejeicao 580 (falha de schema do modal) vem sem protMDFe."""
+        ret = (
+            '<retMDFe versao="3.00" xmlns="http://www.portalfiscal.inf.br/mdfe">'
+            "<tpAmb>2</tpAmb><cUF>33</cUF><cStat>580</cStat>"
+            "<xMotivo>Rejeição: Falha no Schema XML específico para o modal</xMotivo>"
+            "</retMDFe>"
+        )
+        with mock.patch.object(self.con, "_post") as post:
+            post.return_value = _fake_response(200, _soap_response(ret))
+            resultado = self.con.autorizacao(self.manifesto, ind_sinc=1)
+
+        self.assertEqual(resultado[0], 1)
+        ret_mdfe = resultado[1]
+        self.assertEqual(etree.QName(ret_mdfe).localname, "retMDFe")
+        self.assertEqual(ret_mdfe.xpath("ns:cStat", namespaces=NS)[0].text, "580")
+
+    def test_sinc_rejeicao_nivel_protmdfe(self):
+        ret = (
+            '<retMDFe versao="3.00" xmlns="http://www.portalfiscal.inf.br/mdfe">'
+            "<tpAmb>2</tpAmb><cUF>33</cUF><cStat>104</cStat><xMotivo>Lote processado</xMotivo>"
+            '<protMDFe versao="3.00"><infProt><tpAmb>2</tpAmb><cStat>204</cStat>'
+            "<xMotivo>Rejeição: Duplicidade de MDF-e</xMotivo></infProt></protMDFe>"
+            "</retMDFe>"
+        )
+        with mock.patch.object(self.con, "_post") as post:
+            post.return_value = _fake_response(200, _soap_response(ret))
+            resultado = self.con.autorizacao(self.manifesto, ind_sinc=1)
+
+        self.assertEqual(resultado[0], 1)
+        ret_mdfe = resultado[1]
+        self.assertEqual(etree.QName(ret_mdfe).localname, "retMDFe")
+        self.assertEqual(
+            ret_mdfe.xpath("ns:protMDFe/ns:infProt/ns:cStat", namespaces=NS)[0].text, "204"
+        )
+
+    def test_sinc_http_400_corpo_vazio_retorna_response_crua(self):
+        with mock.patch.object(self.con, "_post") as post:
+            post.return_value = _fake_response(400, "")
+            resultado = self.con.autorizacao(self.manifesto, ind_sinc=1)
+
+        self.assertEqual(resultado[0], 1)
+        self.assertIs(resultado[1], post.return_value)
+
+    def test_sinc_corpo_nao_parseavel_retorna_response_crua(self):
+        with mock.patch.object(self.con, "_post") as post:
+            post.return_value = _fake_response(200, "isso nao e xml")
+            resultado = self.con.autorizacao(self.manifesto, ind_sinc=1)
+
+        self.assertEqual(resultado[0], 1)
+        self.assertIs(resultado[1], post.return_value)
+
+
+class SerializacaoValePedTestCase(unittest.TestCase):
+    def _modal(self, **kwargs):
+        condutor = ManifestoCondutor(nome_motorista="JOAO DA SILVA", cpf_motorista="12345678912")
+        veiculo_tracao = [
+            ManifestoVeiculoTracao(
+                cInt="001",
+                placa="ABC1234",
+                RENAVAM="123456789",
+                tara=Decimal("5000"),
+                capKG=Decimal("4500"),
+                capM3=Decimal("400"),
+                proprietario=None,
+                condutor=[condutor],
+                tpRod="01",
+                tpCar="02",
+                UF="MT",
+            )
+        ]
+        params = dict(
+            rntrc=None,
+            ciot=[],
+            pedagio=[],
+            contratante=[],
+            pagamento=None,
+            veiculo_tracao=veiculo_tracao,
+            veiculo_reboque=[],
+        )
+        params.update(kwargs)
+        return ManifestoRodoviario(**params)
+
+    def _serializar(self, modal):
+        serializador = SerializacaoMDFe.__new__(SerializacaoMDFe)
+        serializador._versao = "3.00"
+        return serializador._serializar_modal_rodoviario(modal, retorna_string=False)
+
+    def test_vale_ped_omitido_sem_disp(self):
+        """valePed vazio e rejeitado pelo schema do modal (cStat 580) e deve ser omitido."""
+        raiz = self._serializar(self._modal(rntrc="12345678"))
+        self.assertEqual(len(raiz.xpath("rodo/infANTT/valePed")), 0)
+        self.assertEqual(len(raiz.xpath("rodo/infANTT/RNTRC")), 1)
+
+    def test_inf_antt_omitido_quando_totalmente_vazio(self):
+        raiz = self._serializar(self._modal())
+        self.assertEqual(len(raiz.xpath("rodo/infANTT")), 0)
+        self.assertEqual(len(raiz.xpath("rodo/veicTracao")), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Contexto (DEV-2266 round 2)

A transmissao do MDF-e para a SVRS falhava com HTTP 400 e corpo vazio no servico `MDFeRecepcaoSinc`. Root cause verificado ao vivo em homologacao:

1. O envio sincrono mandava o `<enviMDFe>` puro dentro de `mdfeDadosMsg`, mas o MOC do MDF-e exige o XML assinado do `<MDFe>` **compactado com gzip e codificado em base64** como conteudo texto de `mdfeDadosMsg` (sem envelope `enviMDFe`/`idLote`).
2. Com o request correto, a SVRS respondeu cStat 580 (falha de schema do modal) porque o serializador emitia `<valePed/>` vazio dentro de `infANTT`.

## Mudancas

- `ComunicacaoMDFe.autorizacao` (ind_sinc=1) extraido para `_autorizacao_sincrona`: envia `base64(gzip(MDFe))` como texto de `mdfeDadosMsg`, com `Content-Type: application/soap+xml; charset=utf-8` (SOAP 1.2). Caminho assincrono (ind_sinc=0) inalterado.
- Parse da resposta sincrona (`retMDFe` dentro de `mdfeRecepcaoResult`):
  - `protMDFe/infProt/cStat` em 100/101/132 -> `(0, mdfeProc)` (contrato de sucesso preservado);
  - rejeicao (retMDFe-level, ex. 580 sem protMDFe, ou protMDFe-level) -> `(1, retMDFe, manifesto)` para o chamador consultar cStat/xMotivo;
  - resposta HTTP crua somente quando nao-200 ou corpo nao parseavel.
- `_serializar_modal_rodoviario`: omite `valePed` sem entradas `disp` e omite `infANTT` quando totalmente vazio.

## Testes

- Novo `tests/test_mdfe_comunicacao_sinc.py`: construcao do envelope gzip+base64, sucesso (mdfeProc), rejeicao 580 sem protMDFe, rejeicao no protMDFe, HTTP 400 corpo vazio, corpo nao parseavel, omissao de valePed/infANTT.
- Suite completa: 163 passed. `ruff check` e `ruff format --check` limpos.
