### PR TITLE
fix(nfce): NFC-e de GO transmitida para o portal de consulta em vez do autorizador [DEV-2468]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,14 @@ This allows you to navigate directly to the specific line-window you need instea
 
 | Source Map | File | Lines | Description |
 |------------|------|-------|-------------|
-| `docs/serializacao_map.md` | `pynfe/processamento/serializacao.py` | 2630 | XML serialization (NF-e, MDF-e, QR codes) |
+| `docs/serializacao_map.md` | `pynfe/processamento/serializacao.py` | 2895 | XML serialization (NF-e, MDF-e, QR codes) |
 | `docs/comunicacao_map.md` | `pynfe/processamento/comunicacao.py` | 1348 | SEFAZ webservice communication |
 | `docs/autorizador_nfse_map.md` | `pynfe/processamento/autorizador_nfse.py` | 538 | NFS-e authorization (Betha/Ginfes) |
 | `docs/notafiscal_map.md` | `pynfe/entidades/notafiscal.py` | 1253 | Invoice entities and tax fields |
 | `docs/manifesto_map.md` | `pynfe/entidades/manifesto.py` | 447 | MDF-e manifest entities |
 | `docs/evento_map.md` | `pynfe/entidades/evento.py` | 237 | Event entities (cancel, correction, etc.) |
 | `docs/flags_map.md` | `pynfe/utils/flags.py` | 645 | Constants, namespaces, tax codes |
-| `docs/webservices_map.md` | `pynfe/utils/webservices.py` | 572 | SEFAZ endpoint URLs by state |
+| `docs/webservices_map.md` | `pynfe/utils/webservices.py` | 612 | SEFAZ endpoint URLs by state |
 | `docs/utils_map.md` | `pynfe/utils/__init__.py` | 253 | Utility functions (municipality lookup, signing) |
 
 ### How to Use Source Maps
@@ -113,3 +113,10 @@ ruff format pynfe/
 - The `pynfe/data/` directory contains reference data files that should not be modified casually
 - Tax code serialization follows strict SEFAZ XML schema ordering — field order matters
 - Each Brazilian state has its own SEFAZ endpoint configuration in `webservices.py`
+- **A UF's consultation portal host and its authorizer host are different endpoints.** In
+  `webservices.py`, `HTTPS`/`HOMOLOGACAO` are authorizer host prefixes read only by
+  `ComunicacaoSefaz._get_url`; `QR_HOST`/`QR_HOST_HOMOLOGACAO` are consultation-portal host
+  prefixes read only by `qrcode_host` (used for `<qrCode>`/`<urlChave>`). Never make one key
+  serve both roles: a webservice pointed at the consultation portal gets a redirect plus HTML
+  instead of a SEFAZ verdict, so emissions fail as transport errors with no rejeicao to explain
+  them. When a UF changes its consultation host, touch only the `QR_*` keys

--- a/docs/serializacao_map.md
+++ b/docs/serializacao_map.md
@@ -1,4 +1,4 @@
-# Source Map: `serializacao.py` (2771 lines)
+# Source Map: `serializacao.py` (2895 lines)
 
 XML serialization of NF-e, NFC-e, NFS-e and MDF-e documents into SEFAZ-compliant XML format.
 

--- a/docs/webservices_map.md
+++ b/docs/webservices_map.md
@@ -1,4 +1,4 @@
-# Source Map: `webservices.py` (572 lines)
+# Source Map: `webservices.py` (612 lines)
 
 SEFAZ webservice endpoint URLs organized by document type, state, and environment.
 
@@ -22,10 +22,18 @@ Each state/virtual environment entry contains:
 - `INUTILIZACAO` — Number invalidation endpoint
 - `EVENTOS` — Event reception endpoint
 - `CADASTRO` — Registration query endpoint (some states)
-- `HTTPS` — Production base URL prefix
-- `HOMOLOGACAO` — Homologation base URL prefix
-- `QR` — QR Code URL (NFC-e only)
-- `URL` — Consultation URL (NFC-e only)
+- `HTTPS` — Production base URL prefix of the AUTHORIZER (webservices; read only by
+  `ComunicacaoSefaz._get_url`)
+- `HOMOLOGACAO` — Homologation base URL prefix of the AUTHORIZER
+- `QR_HOST` / `QR_HOST_HOMOLOGACAO` — Base URL prefix of the CONSULTATION portal, used for
+  `<qrCode>`/`<urlChave>` (read only by `qrcode_host`); falls back to `HTTPS`/`HOMOLOGACAO`
+  for UFs that serve both roles from the same host
+- `QR` — QR Code path (NFC-e only; `QR_HOMOLOGACAO` where the path differs per environment)
+- `URL` — Consultation path (NFC-e only)
+
+The two host families must never be shared: a UF such as GO answers webservice POSTs sent to
+its consultation host with a load-balancer redirect and HTML, so the invoice never receives a
+SEFAZ verdict and the failure surfaces as a transport/XML-parse error, not a rejeicao.
 
 ## State/Virtual Environment Groups
 
@@ -61,3 +69,9 @@ Only `SVRS` — single authorizer for all states.
 | Individual states | 524-558 | MT, MS, MG, PR, RS, SP |
 | `SVRS` | 560-565 | Virtual SEFAZ RS |
 | `SVSP` | 566-571 | Virtual SEFAZ SP (AP, PE, RR) |
+
+## Helpers
+
+| Function | Lines | Purpose |
+|----------|-------|---------|
+| `qrcode_host(uf, producao=True)` | 323-335 | Consultation-portal host prefix for `<qrCode>`/`<urlChave>`, with fallback to the webservice host |

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -25,7 +25,7 @@ from pynfe.utils.flags import (
     VERSAO_PADRAO,
     VERSAO_QRCODE,
 )
-from pynfe.utils.webservices import MDFE, NFCE
+from pynfe.utils.webservices import MDFE, NFCE, qrcode_host
 
 
 class Serializacao(object):
@@ -2286,42 +2286,28 @@ class SerializacaoQrcode(object):
             qrcode = NFCE[uf]["QR"] + url
             url_chave = NFCE[uf]["URL"]
         elif uf == "SP":
-            if tpamb == "1":
-                qrcode = NFCE[uf]["HTTPS"] + "www." + NFCE[uf]["QR"] + url
-                url_chave = NFCE[uf]["HTTPS"] + "www." + NFCE[uf]["URL"]
-            else:
-                qrcode = NFCE[uf]["HTTPS"] + "www.homologacao." + NFCE[uf]["QR"] + url
-                url_chave = NFCE[uf]["HTTPS"] + "www.homologacao." + NFCE[uf]["URL"]
+            host = qrcode_host(uf, producao=tpamb == "1")
+            qrcode = host + NFCE[uf]["QR"] + url
+            url_chave = host + NFCE[uf]["URL"]
         # BA tem comportamento distindo para qrcode e url
         elif uf == "BA":
-            if tpamb == "1":
-                qrcode = NFCE[uf]["HTTPS"] + NFCE[uf]["QR"] + url
-            else:
-                qrcode = NFCE[uf]["HOMOLOGACAO"] + NFCE[uf]["QR"] + url
-            url_chave = url_chave = NFCE[uf]["URL"]
+            qrcode = qrcode_host(uf, producao=tpamb == "1") + NFCE[uf]["QR"] + url
+            url_chave = NFCE[uf]["URL"]
         # MG tem comportamento distintos para qrcode e url
         elif uf == "MG":
             qrcode = NFCE[uf]["QR"] + url
-            if tpamb == "1":
-                url_chave = NFCE[uf]["HTTPS"] + NFCE[uf]["URL"]
-            else:
-                url_chave = NFCE[uf]["HOMOLOGACAO"] + NFCE[uf]["URL"]
+            url_chave = qrcode_host(uf, producao=tpamb == "1") + NFCE[uf]["URL"]
         # AM tem comportamento distintos para qrcode e url
         elif uf == "AM":
-            if tpamb == "1":
-                qrcode = NFCE[uf]["HTTPS"] + NFCE[uf]["QR"] + url
-                url_chave = NFCE[uf]["HTTPS"] + NFCE[uf]["URL"]
-            else:
-                qrcode = NFCE[uf]["HTTPS"] + NFCE[uf]["QR_HOMOLOGACAO"] + url
-                url_chave = NFCE[uf]["HTTPS"] + NFCE[uf]["URL"]
-        # AC, RR, PA, SE
+            host = qrcode_host(uf, producao=tpamb == "1")
+            caminho_qr = NFCE[uf]["QR"] if tpamb == "1" else NFCE[uf]["QR_HOMOLOGACAO"]
+            qrcode = host + caminho_qr + url
+            url_chave = host + NFCE[uf]["URL"]
+        # AC, RR, PA, SE, GO
         else:
-            if tpamb == "1":
-                qrcode = NFCE[uf]["HTTPS"] + NFCE[uf]["QR"] + url
-                url_chave = NFCE[uf]["HTTPS"] + NFCE[uf]["URL"]
-            else:
-                qrcode = NFCE[uf]["HOMOLOGACAO"] + NFCE[uf]["QR"] + url
-                url_chave = NFCE[uf]["HOMOLOGACAO"] + NFCE[uf]["URL"]
+            host = qrcode_host(uf, producao=tpamb == "1")
+            qrcode = host + NFCE[uf]["QR"] + url
+            url_chave = host + NFCE[uf]["URL"]
         # adicionta tag infNFeSupl com qrcode
         info = etree.Element("infNFeSupl")
         etree.SubElement(info, "qrCode").text = etree.CDATA(qrcode.strip())

--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -1,5 +1,21 @@
 """
 @author: Junior Tada, Leonardo Tada
+
+Host de CONSULTA vs host de AUTORIZADOR
+---------------------------------------
+Numa UF, o portal publico de consulta (destino do ``<qrCode>``/``<urlChave>``) e o
+autorizador (webservices SOAP com mTLS) podem ser servidores DIFERENTES. Por isso as
+duas familias de chave sao separadas em ``NFCE`` e nunca devem ser reaproveitadas
+uma pela outra:
+
+- ``HTTPS`` / ``HOMOLOGACAO``: prefixo de host do AUTORIZADOR, lido apenas por
+  ``ComunicacaoSefaz._get_url`` para montar URLs de webservice.
+- ``QR_HOST`` / ``QR_HOST_HOMOLOGACAO``: prefixo de host do portal de CONSULTA, lido
+  apenas por ``qrcode_host`` (usado em ``SerializacaoQrcode.gerar_qrcode``).
+
+Apontar webservice para o host de consulta nao gera rejeicao: o portal responde
+redirect + HTML, entao a nota nunca recebe veredito da SEFAZ. Ao atualizar o host de
+consulta de uma UF, mexa somente nas chaves ``QR_*``.
 """
 
 # http://nfce.encat.org/desenvolvedor/qrcode/
@@ -36,6 +52,8 @@ NFCE = {
         "URL": "sefaz.am.gov.br/nfceweb/formConsulta.do",
         "HTTPS": "https://sistemas.",
         "HOMOLOGACAO": "https://hom",
+        "QR_HOST": "https://sistemas.",
+        "QR_HOST_HOMOLOGACAO": "https://sistemas.",
     },
     "RR": {
         "STATUS": "",
@@ -209,6 +227,8 @@ NFCE = {
         "URL": "nfce.fazenda.sp.gov.br/consulta",
         "HTTPS": "https://",
         "HOMOLOGACAO": "https://homologacao.",
+        "QR_HOST": "https://www.",
+        "QR_HOST_HOMOLOGACAO": "https://www.homologacao.",
     },
     "PR": {
         "STATUS": "nfce.sefa.pr.gov.br/nfce/NFeStatusServico4?wsdl",
@@ -273,8 +293,12 @@ NFCE = {
         "EVENTOS": "sefaz.go.gov.br/nfe/services/NFeRecepcaoEvento4?wsdl",
         "QR": "sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe?",
         "CADASTRO": "sefaz.go.gov.br/nfe/services/CadConsultaCadastro4?wsdl",
-        "HTTPS": "https://nfeweb.",
-        "HOMOLOGACAO": "https://nfewebhomolog.",
+        # Host do AUTORIZADOR (webservices SOAP, mTLS) - igual ao de NFE["GO"].
+        "HTTPS": "https://nfe.",
+        "HOMOLOGACAO": "https://homolog.",
+        # Host do portal de CONSULTA (qrCode/urlChave) - IT 2025.003, DEV-2177.
+        "QR_HOST": "https://nfeweb.",
+        "QR_HOST_HOMOLOGACAO": "https://nfewebhomolog.",
         "URL": "sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe",
     },
     "DF": {
@@ -294,6 +318,21 @@ NFCE = {
         "HOMOLOGACAO": "https://nfce-homologacao.",
     },
 }
+
+
+def qrcode_host(uf, producao=True):
+    """Prefixo de host do portal de consulta usado no ``<qrCode>``/``<urlChave>``.
+
+    Prefere as chaves dedicadas ``QR_HOST``/``QR_HOST_HOMOLOGACAO``; para UFs que nao
+    declaram host de consulta proprio (portal e autorizador no mesmo servidor), cai no
+    host de webservice, preservando o comportamento historico.
+    """
+    dados = NFCE[uf]
+    chave_qr = "QR_HOST" if producao else "QR_HOST_HOMOLOGACAO"
+    if dados.get(chave_qr):
+        return dados[chave_qr]
+    return dados["HTTPS"] if producao else dados["HOMOLOGACAO"]
+
 
 # Nfe
 # homologação => http://hom.nfe.fazenda.gov.br/PORTAL/WebServices.aspx

--- a/tests/processamento/test_comunicacao_url_nfce_go.py
+++ b/tests/processamento/test_comunicacao_url_nfce_go.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# *-* encoding: utf8 *-*
+"""Regression tests for the GO NFC-e WEBSERVICE host (autorizador, not consulta portal).
+
+GO serves the public consultation portal (``nfeweb.sefaz.go.gov.br``, destination of
+``<qrCode>``/``<urlChave>``) and the SOAP authorizer (``nfe.sefaz.go.gov.br``) from
+different hosts. Pointing the webservice URL at the consultation portal does NOT produce
+a SEFAZ rejeicao: the portal answers a BigIP redirect plus HTML, so the invoice never gets
+a verdict at all and every emission fails as a transport error. These tests pin the
+authorizer host for NFC-e to the same host used for NF-e, and keep the QR host separate.
+See DEV-2468.
+"""
+
+import unittest
+
+from pynfe.processamento.comunicacao import ComunicacaoSefaz
+from pynfe.utils.webservices import NFCE, NFE, qrcode_host
+
+CONSULTAS = ["AUTORIZACAO", "STATUS", "EVENTOS", "INUTILIZACAO", "CHAVE"]
+
+URL_AUTORIZACAO_PRODUCAO = "https://nfe.sefaz.go.gov.br/nfe/services/NFeAutorizacao4?wsdl"
+URL_AUTORIZACAO_HOMOLOGACAO = "https://homolog.sefaz.go.gov.br/nfe/services/NFeAutorizacao4?wsdl"
+
+
+def _comunicacao(homologacao):
+    return ComunicacaoSefaz(
+        uf="go",
+        certificado="./tests/certificado.pfx",
+        certificado_senha=bytes("123456", "utf-8"),
+        homologacao=homologacao,
+    )
+
+
+class UrlWebserviceNFCeGoTestCase(unittest.TestCase):
+    def test_autorizacao_producao_aponta_para_autorizador(self):
+        url = _comunicacao(homologacao=False)._get_url(modelo="nfce", consulta="AUTORIZACAO")
+        self.assertEqual(url, URL_AUTORIZACAO_PRODUCAO)
+
+    def test_autorizacao_homologacao_aponta_para_autorizador(self):
+        url = _comunicacao(homologacao=True)._get_url(modelo="nfce", consulta="AUTORIZACAO")
+        self.assertEqual(url, URL_AUTORIZACAO_HOMOLOGACAO)
+
+    def test_nfce_usa_o_mesmo_host_da_nfe(self):
+        for homologacao in (False, True):
+            nfce = _comunicacao(homologacao=homologacao)
+            nfe = _comunicacao(homologacao=homologacao)
+            for consulta in CONSULTAS:
+                url_nfce = nfce._get_url(modelo="nfce", consulta=consulta)
+                url_nfe = nfe._get_url(modelo="nfe", consulta=consulta)
+                self.assertEqual(
+                    url_nfce.split("/")[2],
+                    url_nfe.split("/")[2],
+                    f"host de {consulta} (homologacao={homologacao}) divergiu entre nfce e nfe",
+                )
+
+    def test_webservice_nunca_usa_host_do_portal_de_consulta(self):
+        for homologacao in (False, True):
+            comunicacao = _comunicacao(homologacao=homologacao)
+            for consulta in CONSULTAS:
+                url = comunicacao._get_url(modelo="nfce", consulta=consulta)
+                self.assertNotIn("nfeweb", url, f"{consulta} aponta para o portal de consulta")
+
+
+class QrcodeHostTestCase(unittest.TestCase):
+    def test_go_mantem_host_do_portal_de_consulta(self):
+        self.assertEqual(qrcode_host("GO", producao=True), "https://nfeweb.")
+        self.assertEqual(qrcode_host("GO", producao=False), "https://nfewebhomolog.")
+
+    def test_uf_sem_host_de_qr_cai_no_host_de_webservice(self):
+        self.assertEqual(qrcode_host("SE", producao=True), NFCE["SE"]["HTTPS"])
+        self.assertEqual(qrcode_host("SE", producao=False), NFCE["SE"]["HOMOLOGACAO"])
+
+    def test_sp_e_am_mantem_o_host_de_qr_historico(self):
+        # SP e AM tinham o host de QR montado a partir da chave de webservice; os valores
+        # abaixo travam a equivalencia byte a byte apos a separacao das chaves.
+        self.assertEqual(qrcode_host("SP", producao=True), NFCE["SP"]["HTTPS"] + "www.")
+        self.assertEqual(
+            qrcode_host("SP", producao=False), NFCE["SP"]["HTTPS"] + "www.homologacao."
+        )
+        self.assertEqual(qrcode_host("AM", producao=True), NFCE["AM"]["HTTPS"])
+        self.assertEqual(qrcode_host("AM", producao=False), NFCE["AM"]["HTTPS"])
+
+    def test_chaves_de_qr_e_de_webservice_de_go_sao_distintas(self):
+        self.assertEqual(NFCE["GO"]["HTTPS"], NFE["GO"]["HTTPS"])
+        self.assertEqual(NFCE["GO"]["HOMOLOGACAO"], NFE["GO"]["HOMOLOGACAO"])
+        self.assertNotEqual(NFCE["GO"]["HTTPS"], NFCE["GO"]["QR_HOST"])
+        self.assertNotEqual(NFCE["GO"]["HOMOLOGACAO"], NFCE["GO"]["QR_HOST_HOMOLOGACAO"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nfce_qrcode_hosts_por_uf.py
+++ b/tests/test_nfce_qrcode_hosts_por_uf.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# *-* encoding: utf8 *-*
+"""Pins the ``<qrCode>``/``<urlChave>`` host of every UF whose branch reads a host prefix.
+
+The GO fix (DEV-2468) routed those branches through ``webservices.qrcode_host`` so the QR
+host can no longer be taken from the authorizer keys. These tests lock the resulting URLs
+for SP, AM, BA and MG in both environments, which is what makes the refactor verifiable as
+byte-identical outside GO.
+"""
+
+import unittest
+
+from lxml import etree
+
+from pynfe.processamento.serializacao import SerializacaoQrcode
+from pynfe.utils.flags import CODIGOS_ESTADOS, NAMESPACE_NFE, NAMESPACE_SIG
+
+TP_AMB_PRODUCAO = "1"
+TP_AMB_HOMOLOGACAO = "2"
+
+# uf -> (prefixo esperado do qrCode, urlChave esperada) por ambiente.
+ESPERADO = {
+    "SP": {
+        TP_AMB_PRODUCAO: (
+            "https://www.nfce.fazenda.sp.gov.br/NFCeConsultaPublica/Paginas/ConsultaQRCode.aspx?",
+            "https://www.nfce.fazenda.sp.gov.br/consulta",
+        ),
+        TP_AMB_HOMOLOGACAO: (
+            "https://www.homologacao.nfce.fazenda.sp.gov.br/NFCeConsultaPublica/Paginas/"
+            "ConsultaQRCode.aspx?",
+            "https://www.homologacao.nfce.fazenda.sp.gov.br/consulta",
+        ),
+    },
+    "AM": {
+        TP_AMB_PRODUCAO: (
+            "https://sistemas.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp?",
+            "https://sistemas.sefaz.am.gov.br/nfceweb/formConsulta.do",
+        ),
+        TP_AMB_HOMOLOGACAO: (
+            "https://sistemas.sefaz.am.gov.br/nfceweb-hom/consultarNFCe.jsp?",
+            "https://sistemas.sefaz.am.gov.br/nfceweb/formConsulta.do",
+        ),
+    },
+    "BA": {
+        TP_AMB_PRODUCAO: (
+            "http://nfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx?",
+            "http://hinternet.sefaz.ba.gov.br/nfce/consulta",
+        ),
+        TP_AMB_HOMOLOGACAO: (
+            "http://hnfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx?",
+            "http://hinternet.sefaz.ba.gov.br/nfce/consulta",
+        ),
+    },
+    "MG": {
+        TP_AMB_PRODUCAO: (
+            "https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml",
+            "https://nfce.fazenda.mg.gov.br/portalnfce",
+        ),
+        TP_AMB_HOMOLOGACAO: (
+            "https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml",
+            "https://hnfce.fazenda.mg.gov.br/portalnfce",
+        ),
+    },
+}
+
+
+def _nfe(uf, tp_amb):
+    cuf = CODIGOS_ESTADOS[uf]
+    chave = cuf + "0" * 42
+    xml = (
+        f'<NFe xmlns="{NAMESPACE_NFE}">'
+        f'<infNFe Id="NFe{chave}">'
+        f"<ide><cUF>{cuf}</cUF><dhEmi>2025-01-14T12:00:00-03:00</dhEmi>"
+        f"<tpAmb>{tp_amb}</tpAmb></ide>"
+        f"<dest><CPF>12345678900</CPF></dest>"
+        f"<total><ICMSTot><vNF>10.00</vNF></ICMSTot></total>"
+        f"</infNFe>"
+        f'<Signature xmlns="{NAMESPACE_SIG}"><SignedInfo><Reference>'
+        f"<DigestValue>ABCDEF==</DigestValue>"
+        f"</Reference></SignedInfo></Signature>"
+        f"</NFe>"
+    )
+    return etree.fromstring(xml.encode())
+
+
+class QrcodeHostsPorUfTestCase(unittest.TestCase):
+    def test_hosts_de_qrcode_e_urlchave(self):
+        for uf, ambientes in ESPERADO.items():
+            for tp_amb, (prefixo_qr, url_chave_esperada) in ambientes.items():
+                with self.subTest(uf=uf, tpAmb=tp_amb):
+                    nfe, qrcode = SerializacaoQrcode().gerar_qrcode(
+                        "000001", "CSC123", _nfe(uf, tp_amb), return_qr=True
+                    )
+                    url_chave = nfe.find("infNFeSupl").find("urlChave").text
+                    self.assertTrue(
+                        qrcode.startswith(prefixo_qr),
+                        f"{uf}/{tp_amb}: qrCode deveria comecar com {prefixo_qr}, veio {qrcode}",
+                    )
+                    self.assertEqual(url_chave, url_chave_esperada)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

Toda autorização de NFC-e de Goiás era POSTada para o **portal de consulta**, não para o autorizador:

```
https://nfeweb.sefaz.go.gov.br/nfe/services/NFeAutorizacao4?wsdl
```

O host `nfeweb.` responde com redirect de BigIP + HTML, o que produz
`XMLSyntaxError: Invalid bytes in character encoding, line 6, column 13` no cliente — classificado como
falha transiente de transporte. Como o portal nunca devolve um retorno SEFAZ, a nota **não recebe veredito
nenhum**: não autoriza e não é rejeitada.

## Mecanismo (chave compartilhada)

As chaves `HTTPS` / `HOMOLOGACAO` de `NFCE["GO"]` eram lidas por **dois consumidores com papéis diferentes**:

- `SerializacaoQrcode.gerar_qrcode` — host do **portal de consulta** (destino do `<qrCode>`/`<urlChave>`);
- `ComunicacaoSefaz._get_url` — host do **autorizador** (webservices SOAP com mTLS).

Em GO esses dois papéis moram em servidores distintos (`nfeweb.sefaz.go.gov.br` vs `nfe.sefaz.go.gov.br`),
então atualizar o host do QRCode para `nfeweb.` (correto, IT 2025.003) arrastou o host de webservice junto.

Hosts verificados ao vivo (read-only):

- `nfeweb.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl` → **302** (Server: BigIP) para
  `/nfeweb/sites/nfe/consulta-completa`; POST após o redirect → **405** com `Content-Type: text/html`.
- `nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4?wsdl` → handshake TLS exige certificado de **cliente**
  (`sslv3 alert certificate unknown`) — assinatura do endpoint SOAP real.
- `homolog.sefaz.go.gov.br` → idem (mTLS). `nfce.sefaz.go.gov.br` → NXDOMAIN (GO não tem host separado de NFC-e).

## Evidência de produção

Loja 394 (Bolina Café & Bistro, licença 420, Senador Canedo/GO) — única loja de GO na base — acumula
**2055 cupons desde 2026-06-13 com `cstat = 0` em todos**: nenhuma autorização e nenhuma rejeição, ou seja,
nunca chegou veredito da SEFAZ. Isso também absolve certificado (id 257, válido até 2027-06-29) e
CSC/credenciamento: credencial errada geraria *rejeição*, não silêncio.

O painel do PDV ficava "Sefaz Online" porque a sonda de status consulta `modelo="nfe"`, que resolve para
`NFE["GO"]["HTTPS"]` = `https://nfe.sefaz.go.gov.br` — o autorizador real, que está no ar.

## Isto NÃO é um revert

O `<qrCode>`/`<urlChave>` de GO **continua** em `nfeweb.` / `nfewebhomolog.` (IT 2025.003, DEV-2177). Reverter
aquele commit trocaria este bug pela rejeição 395, e o qrCode entra assinado dentro do XML.

## Solução

- `NFCE["GO"]["HTTPS"] / ["HOMOLOGACAO"]` voltam ao host do autorizador (`https://nfe.` / `https://homolog.`,
  idênticos a `NFE["GO"]`) e passam a ser lidos **só** por `ComunicacaoSefaz._get_url`.
- Chaves novas e dedicadas `QR_HOST` / `QR_HOST_HOMOLOGACAO` (`https://nfeweb.` / `https://nfewebhomolog.`)
  carregam o host do portal de consulta, lidas **só** pelo novo helper `webservices.qrcode_host`.
- Todos os ramos de `gerar_qrcode` que montavam host (SP, AM, BA, MG e o `else` onde GO cai) passam pelo
  helper, de modo que nenhum leitor de QR toque mais nas chaves de webservice. Os valores de `QR_HOST` de SP e
  AM reproduzem a concatenação antiga, então a saída fica **byte a byte idêntica** fora de GO (travado em teste).
- Fallback compatível: UFs sem `QR_*` continuam usando `HTTPS`/`HOMOLOGACAO` pelo helper — nenhum `KeyError`
  novo em nenhum caminho.

## Varredura das outras UFs (item solicitado)

Comparei, para cada UF com webservice de NFC-e próprio, o host de QR com o host de autorizador. **GO é a única
UF onde a divergência estava causando falha de emissão hoje.** Duas divergências latentes ficaram registradas e
NÃO foram alteradas (mudá-las quebraria a garantia de byte-identidade e não há como validar os endpoints ao vivo
sem certificado da UF):

- **AM** — `NFCE["AM"]["HTTPS"] = "https://sistemas."` serve tanto o QR (correto) quanto o webservice, gerando
  `https://sistemas.nfce.sefaz.am.gov.br/nfce-services/...`, que não é o autorizador de AM. Mesmo acidente, sem
  cliente em AM para expor.
- **MT / CE** — estão na lista de UFs com webservice próprio de NFC-e, mas `NFCE["MT"]`/`NFCE["CE"]` só têm
  chaves de QR (sem `AUTORIZACAO`/`HTTPS`), então uma emissão de NFC-e nessas UFs levanta `KeyError` antes de
  sair. Também latente.

## Testes

- `tests/processamento/test_comunicacao_url_nfce_go.py` — host de `AUTORIZACAO`, `STATUS`, `EVENTOS`,
  `INUTILIZACAO` e `CHAVE` no modelo `nfce` de GO tem de ser igual ao do modelo `nfe` (produção e homologação);
  URL de autorização ponta a ponta com a string completa esperada; nenhuma URL de webservice pode conter
  `nfeweb`; fallback do helper para UF sem `QR_*`.
- `tests/test_nfce_qrcode_hosts_por_uf.py` — trava `qrCode`/`urlChave` de SP, AM, BA e MG nos dois ambientes
  (garantia de byte-identidade do refactor).
- `tests/test_nfce_qrcode_go.py` (já existente, DEV-2177) continua verde: QR de GO segue em `nfeweb.`.

Suíte completa: **172 testes + 8 subtests passando**, `ruff check` e `ruff format --check` limpos.

## Doc

A distinção "host de consulta vs host de autorizador" ficou registrada de forma durável no docstring de
`pynfe/utils/webservices.py`, no `AGENTS.md` e em `docs/webservices_map.md`.

## Etapa 2/2

O bump do pin no `api` é separado e será feito depois deste merge.
