### PR TITLE
fix(nfce): host de webservice de AM apontava para host inexistente [DEV-2468]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This allows you to navigate directly to the specific line-window you need instea
 | `docs/manifesto_map.md` | `pynfe/entidades/manifesto.py` | 447 | MDF-e manifest entities |
 | `docs/evento_map.md` | `pynfe/entidades/evento.py` | 237 | Event entities (cancel, correction, etc.) |
 | `docs/flags_map.md` | `pynfe/utils/flags.py` | 645 | Constants, namespaces, tax codes |
-| `docs/webservices_map.md` | `pynfe/utils/webservices.py` | 612 | SEFAZ endpoint URLs by state |
+| `docs/webservices_map.md` | `pynfe/utils/webservices.py` | 615 | SEFAZ endpoint URLs by state |
 | `docs/utils_map.md` | `pynfe/utils/__init__.py` | 253 | Utility functions (municipality lookup, signing) |
 
 ### How to Use Source Maps
@@ -119,4 +119,5 @@ ruff format pynfe/
   prefixes read only by `qrcode_host` (used for `<qrCode>`/`<urlChave>`). Never make one key
   serve both roles: a webservice pointed at the consultation portal gets a redirect plus HTML
   instead of a SEFAZ verdict, so emissions fail as transport errors with no rejeicao to explain
-  them. When a UF changes its consultation host, touch only the `QR_*` keys
+  them. When a UF changes its consultation host, touch only the `QR_*` keys, and when a UF's
+  endpoint paths already embed a subdomain, the authorizer prefix is the scheme alone.

--- a/docs/serializacao_map.md
+++ b/docs/serializacao_map.md
@@ -6,20 +6,20 @@ XML serialization of NF-e, NFC-e, NFS-e and MDF-e documents into SEFAZ-compliant
 
 | Class | Lines | Purpose |
 |-------|-------|---------|
-| `Serializacao` | 30-63 | Abstract base class (not instantiable directly) |
-| `SerializacaoXML` | 66-1860 | Main NF-e/NFC-e XML serialization |
-| `SerializacaoQrcode` | 2102-2206 | NFC-e QR Code generation |
-| `SerializacaoNfse` | 2209-2275 | NFS-e serialization (Betha/Ginfes) |
-| `SerializacaoQrcodeMDFe` | 2278-2301 | MDF-e QR Code generation |
-| `SerializacaoMDFe` | 2304-2771 | MDF-e XML serialization |
+| `Serializacao` | 31-65 | Abstract base class (not instantiable directly) |
+| `SerializacaoXML` | 67-2222 | Main NF-e/NFC-e XML serialization |
+| `SerializacaoQrcode` | 2225-2323 | NFC-e QR Code generation |
+| `SerializacaoNfse` | 2326-2392 | NFS-e serialization (Betha/Ginfes) |
+| `SerializacaoQrcodeMDFe` | 2395-2418 | MDF-e QR Code generation |
+| `SerializacaoMDFe` | 2421-2895 | MDF-e XML serialization |
 
 ---
 
-## `Serializacao` (base class) — Lines 30-63
+## `Serializacao` (base class) — Lines 31-65
 
 Abstract base for all serializers. Stores `_fonte_dados`, `_ambiente` (1=prod, 2=homolog), `_contingencia`, `_so_cpf`.
 
-## `SerializacaoXML` — Lines 66-1860
+## `SerializacaoXML` — Lines 67-2222
 
 ### Exported Methods
 | Method | Lines | Purpose |
@@ -102,19 +102,19 @@ Abstract base for all serializers. Stores `_fonte_dados`, `_ambiente` (1=prod, 2
 
 ---
 
-## `SerializacaoQrcode` — Lines 2102-2206
+## `SerializacaoQrcode` — Lines 2225-2323
 
 Generates NFC-e QR Code URL. Handles online/offline modes and state-specific URL patterns (SP, BA, MG, etc.).
 
-## `SerializacaoNfse` — Lines 2209-2275
+## `SerializacaoNfse` — Lines 2326-2392
 
 Delegates to Betha or Ginfes serializers. Methods: `gerar`, `gerar_lote`, `consultar_nfse`, `consultar_lote`, `consultar_rps`, `consultar_situacao_lote`, `cancelar`.
 
-## `SerializacaoQrcodeMDFe` — Lines 2278-2301
+## `SerializacaoQrcodeMDFe` — Lines 2395-2418
 
 Generates MDF-e QR Code URL using SVRS endpoint.
 
-## `SerializacaoMDFe` — Lines 2304-2771
+## `SerializacaoMDFe` — Lines 2421-2895
 
 ### Methods
 | Method | Lines | Purpose |

--- a/docs/webservices_map.md
+++ b/docs/webservices_map.md
@@ -1,4 +1,4 @@
-# Source Map: `webservices.py` (612 lines)
+# Source Map: `webservices.py` (615 lines)
 
 SEFAZ webservice endpoint URLs organized by document type, state, and environment.
 
@@ -6,11 +6,13 @@ SEFAZ webservice endpoint URLs organized by document type, state, and environmen
 
 | Section | Lines | Variable | Purpose |
 |---------|-------|----------|---------|
-| NFC-e endpoints | 8-295 | `NFCE` | NFC-e webservice URLs and QR Code URLs by state |
-| NF-e endpoints | 297-471 | `NFE` | NF-e webservice URLs by state |
-| NFS-e endpoints | 473-499 | `NFSE` | NFS-e URLs (Betha, Ginfes) |
-| MDF-e endpoints | 501-516 | `MDFE` | MDF-e URLs (SVRS only) |
-| CT-e endpoints | 518-572 | `CTE` | CT-e URLs by state |
+| Host roles (consulta vs autorizador) | 1-22 | — | Module docstring: which key family each consumer may read |
+| NFC-e endpoints | 24-323 | `NFCE` | NFC-e webservice URLs and QR Code URLs by state |
+| `qrcode_host` helper | 326-337 | — | Consultation-portal host prefix for `<qrCode>`/`<urlChave>` |
+| NF-e endpoints | 343-514 | `NFE` | NF-e webservice URLs by state |
+| NFS-e endpoints | 517-542 | `NFSE` | NFS-e URLs (Betha, Ginfes) |
+| MDF-e endpoints | 545-559 | `MDFE` | MDF-e URLs (SVRS only) |
+| CT-e endpoints | 561-615 | `CTE` | CT-e URLs by state |
 
 ## URL Structure
 
@@ -37,41 +39,41 @@ SEFAZ verdict and the failure surfaces as a transport/XML-parse error, not a rej
 
 ## State/Virtual Environment Groups
 
-### NFC-e (`NFCE`) — Lines 8-295
+### NFC-e (`NFCE`) — Lines 24-323
 | Key | Lines | Description |
 |-----|-------|-------------|
-| Individual states | 9-278 | RO, AC, AM, RR, PA, AP, TO, MA, PI, CE, RN, PB, PE, AL, SE, BA, MG, ES, RJ, SP, PR, SC, RS, MS, MT, GO, DF |
-| `SVRS` | 284-294 | Virtual SEFAZ RS (fallback for states without own NFC-e) |
+| Individual states | 25-311 | RO, AC, AM, RR, PA, AP, TO, MA, PI, CE, RN, PB, PE, AL, SE, BA, MG, ES, RJ, SP, PR, SC, RS, MS, MT, GO, DF |
+| `SVRS` | 312-322 | Virtual SEFAZ RS (fallback for states without own NFC-e) |
 
-### NF-e (`NFE`) — Lines 297-471
+### NF-e (`NFE`) — Lines 343-514
 | Key | Lines | Description |
 |-----|-------|-------------|
-| `AN` | 302-309 | National environment (events, distribution) |
-| Individual states | 310-428 | AM, MA, PE, BA, MG, SP, PR, RS, MS, MT, GO |
-| `SVAN` | 430-440 | Virtual SEFAZ AN (MA for NF-e) |
-| `SVRS` | 441-451 | Virtual SEFAZ RS (most states) |
-| `SVC-AN` | 452-460 | Contingency AN |
-| `SVC-RS` | 461-470 | Contingency RS |
+| `AN` | 345-352 | National environment (events, distribution) |
+| Individual states | 353-472 | AM, MA, PE, BA, MG, SP, PR, RS, MS, MT, GO |
+| `SVAN` | 473-483 | Virtual SEFAZ AN (MA for NF-e) |
+| `SVRS` | 484-494 | Virtual SEFAZ RS (most states) |
+| `SVC-AN` | 495-503 | Contingency AN |
+| `SVC-RS` | 504-513 | Contingency RS |
 
-### NFS-e (`NFSE`) — Lines 473-499
+### NFS-e (`NFSE`) — Lines 517-542
 | Key | Lines | Description |
 |-----|-------|-------------|
-| `BETHA` | 476-486 | Betha provider (HTTP WSDL) |
-| `GINFES` | 488-498 | Ginfes provider (HTTPS WSDL) |
+| `BETHA` | 519-530 | Betha provider (HTTP WSDL) |
+| `GINFES` | 531-541 | Ginfes provider (HTTPS WSDL) |
 
-### MDF-e (`MDFE`) — Lines 501-516
-Only `SVRS` — single authorizer for all states.
+### MDF-e (`MDFE`) — Lines 545-559
+Only `SVRS` (547-558) — single authorizer for all states.
 
-### CT-e (`CTE`) — Lines 518-572
+### CT-e (`CTE`) — Lines 561-615
 | Key | Lines | Description |
 |-----|-------|-------------|
-| `AN` | 519-523 | National environment (distribution) |
-| Individual states | 524-558 | MT, MS, MG, PR, RS, SP |
-| `SVRS` | 560-565 | Virtual SEFAZ RS |
-| `SVSP` | 566-571 | Virtual SEFAZ SP (AP, PE, RR) |
+| `AN` | 562-566 | National environment (distribution) |
+| Individual states | 567-602 | MT, MS, MG, PR, RS, SP |
+| `SVRS` | 603-608 | Virtual SEFAZ RS |
+| `SVSP` | 609-614 | Virtual SEFAZ SP (AP, PE, RR) |
 
 ## Helpers
 
 | Function | Lines | Purpose |
 |----------|-------|---------|
-| `qrcode_host(uf, producao=True)` | 323-335 | Consultation-portal host prefix for `<qrCode>`/`<urlChave>`, with fallback to the webservice host |
+| `qrcode_host(uf, producao=True)` | 326-337 | Consultation-portal host prefix for `<qrCode>`/`<urlChave>`, with fallback to the webservice host |

--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -50,8 +50,11 @@ NFCE = {
         "QR": "sefaz.am.gov.br/nfceweb/consultarNFCe.jsp?",
         "QR_HOMOLOGACAO": "sefaz.am.gov.br/nfceweb-hom/consultarNFCe.jsp?",
         "URL": "sefaz.am.gov.br/nfceweb/formConsulta.do",
-        "HTTPS": "https://sistemas.",
+        # Host do AUTORIZADOR (webservices SOAP, mTLS) - os caminhos acima ja embutem o
+        # subdominio "nfce.", entao o prefixo de producao e apenas o esquema.
+        "HTTPS": "https://",
         "HOMOLOGACAO": "https://hom",
+        # Host do portal de CONSULTA (qrCode/urlChave).
         "QR_HOST": "https://sistemas.",
         "QR_HOST_HOMOLOGACAO": "https://sistemas.",
     },

--- a/tests/processamento/test_comunicacao_url_nfce_am.py
+++ b/tests/processamento/test_comunicacao_url_nfce_am.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# *-* encoding: utf8 *-*
+"""Regression tests for the AM NFC-e WEBSERVICE host (autorizador, not consulta portal).
+
+Same defect class as GO (DEV-2468): ``NFCE["AM"]["HTTPS"]`` carried the consultation-portal
+prefix ``https://sistemas.`` while the endpoint paths already embed the ``nfce.`` subdomain,
+so every AM NFC-e webservice URL resolved to ``sistemas.nfce.sefaz.am.gov.br`` — a host that
+does not exist (NXDOMAIN), i.e. AM emission could not even open a connection. Two independent
+facts settle the correct prefix:
+
+- ``NFCE["AM"]["HOMOLOGACAO"] = "https://hom"`` concatenates to ``homnfce.sefaz.am.gov.br``,
+  which resolves and demands a client certificate (TLS alert 42 with "Acceptable client
+  certificate CA names", cert ``CN=*.sefaz.am.gov.br``, ``O=SECRETARIA DE ESTADO DA FAZENDA
+  SEFAZ``) — the mTLS SOAP signature. So the webservice paths are meant to be prefixed with
+  the scheme only, and production must be ``https://`` → ``nfce.sefaz.am.gov.br``, which shows
+  the same certificate and the same client-certificate demand.
+- ``sistemas.sefaz.am.gov.br`` completes the TLS handshake with no client certificate and a
+  plain ``CN=sistemas.sefaz.am.gov.br`` cert — it is the public portal, correct for
+  ``<qrCode>``/``<urlChave>`` and wrong for SOAP.
+
+The QR host stays on ``https://sistemas.`` via ``QR_HOST``; the byte-identity of AM's
+``<qrCode>``/``<urlChave>`` is locked in ``tests/test_nfce_qrcode_hosts_por_uf.py``.
+"""
+
+import unittest
+
+from pynfe.processamento.comunicacao import ComunicacaoSefaz
+from pynfe.utils.webservices import NFCE, qrcode_host
+
+CONSULTAS = ["AUTORIZACAO", "STATUS", "EVENTOS", "INUTILIZACAO", "CHAVE", "RECIBO"]
+
+HOST_AUTORIZADOR_PRODUCAO = "nfce.sefaz.am.gov.br"
+HOST_AUTORIZADOR_HOMOLOGACAO = "homnfce.sefaz.am.gov.br"
+
+URL_AUTORIZACAO_PRODUCAO = "https://nfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4"
+URL_AUTORIZACAO_HOMOLOGACAO = (
+    "https://homnfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4"
+)
+
+
+def _comunicacao(homologacao):
+    return ComunicacaoSefaz(
+        uf="am",
+        certificado="./tests/certificado.pfx",
+        certificado_senha=bytes("123456", "utf-8"),
+        homologacao=homologacao,
+    )
+
+
+class UrlWebserviceNFCeAmTestCase(unittest.TestCase):
+    def test_autorizacao_producao_aponta_para_autorizador(self):
+        url = _comunicacao(homologacao=False)._get_url(modelo="nfce", consulta="AUTORIZACAO")
+        self.assertEqual(url, URL_AUTORIZACAO_PRODUCAO)
+
+    def test_autorizacao_homologacao_aponta_para_autorizador(self):
+        url = _comunicacao(homologacao=True)._get_url(modelo="nfce", consulta="AUTORIZACAO")
+        self.assertEqual(url, URL_AUTORIZACAO_HOMOLOGACAO)
+
+    def test_host_de_webservice_e_o_mesmo_em_todas_as_consultas(self):
+        for homologacao, host_esperado in (
+            (False, HOST_AUTORIZADOR_PRODUCAO),
+            (True, HOST_AUTORIZADOR_HOMOLOGACAO),
+        ):
+            comunicacao = _comunicacao(homologacao=homologacao)
+            for consulta in CONSULTAS:
+                url = comunicacao._get_url(modelo="nfce", consulta=consulta)
+                self.assertEqual(
+                    url.split("/")[2],
+                    host_esperado,
+                    f"host de {consulta} (homologacao={homologacao}) divergiu do autorizador",
+                )
+
+    def test_webservice_nunca_usa_host_do_portal_de_consulta(self):
+        for homologacao in (False, True):
+            comunicacao = _comunicacao(homologacao=homologacao)
+            for consulta in CONSULTAS:
+                url = comunicacao._get_url(modelo="nfce", consulta=consulta)
+                self.assertNotIn("sistemas.", url, f"{consulta} aponta para o portal de consulta")
+
+    def test_chaves_de_qr_e_de_webservice_de_am_sao_distintas(self):
+        self.assertEqual(qrcode_host("AM", producao=True), "https://sistemas.")
+        self.assertNotEqual(NFCE["AM"]["HTTPS"], NFCE["AM"]["QR_HOST"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/processamento/test_comunicacao_url_nfce_go.py
+++ b/tests/processamento/test_comunicacao_url_nfce_go.py
@@ -71,14 +71,14 @@ class QrcodeHostTestCase(unittest.TestCase):
         self.assertEqual(qrcode_host("SE", producao=False), NFCE["SE"]["HOMOLOGACAO"])
 
     def test_sp_e_am_mantem_o_host_de_qr_historico(self):
-        # SP e AM tinham o host de QR montado a partir da chave de webservice; os valores
-        # abaixo travam a equivalencia byte a byte apos a separacao das chaves.
-        self.assertEqual(qrcode_host("SP", producao=True), NFCE["SP"]["HTTPS"] + "www.")
-        self.assertEqual(
-            qrcode_host("SP", producao=False), NFCE["SP"]["HTTPS"] + "www.homologacao."
-        )
-        self.assertEqual(qrcode_host("AM", producao=True), NFCE["AM"]["HTTPS"])
-        self.assertEqual(qrcode_host("AM", producao=False), NFCE["AM"]["HTTPS"])
+        # SP e AM tinham o host de QR montado a partir da chave de webservice; os literais
+        # abaixo travam a equivalencia byte a byte apos a separacao das chaves. Sao literais
+        # de proposito: derivar o esperado de NFCE[uf]["HTTPS"] tornaria a trava vazia
+        # justamente quando essa chave for corrigida.
+        self.assertEqual(qrcode_host("SP", producao=True), "https://www.")
+        self.assertEqual(qrcode_host("SP", producao=False), "https://www.homologacao.")
+        self.assertEqual(qrcode_host("AM", producao=True), "https://sistemas.")
+        self.assertEqual(qrcode_host("AM", producao=False), "https://sistemas.")
 
     def test_chaves_de_qr_e_de_webservice_de_go_sao_distintas(self):
         self.assertEqual(NFCE["GO"]["HTTPS"], NFE["GO"]["HTTPS"])


### PR DESCRIPTION
## Contexto

Revisão pós-merge do #8 (DEV-2468). O #8 corrigiu GO e **registrou AM como divergência latente
não alterada**, com a justificativa de que mexer nela quebraria a garantia de byte-identidade do
refactor. Essa justificativa deixou de valer no próprio #8: como AM ganhou `QR_HOST` /
`QR_HOST_HOMOLOGACAO`, o `<qrCode>` de AM não lê mais a chave de webservice, então corrigir
`HTTPS` não toca no QR.

E AM não é só latente — está quebrado de forma pior que GO.

## O defeito

`NFCE["AM"]["HTTPS"]` era `"https://sistemas."`, mas os caminhos de endpoint de AM já embutem o
subdomínio `nfce.`:

```python
"AUTORIZACAO": "nfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4"
```

Resultado em produção:

```
https://sistemas.nfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4
```

```
$ curl https://sistemas.nfce.sefaz.am.gov.br/...
curl: (6) Could not resolve host: sistemas.nfce.sefaz.am.gov.br
```

**NXDOMAIN.** Emissão de NFC-e em AM não conseguia nem abrir conexão — não é o silêncio do GO
(portal responde HTML), é falha de resolução de nome. Nenhum cliente em AM hoje, então nada pode
regredir: o estado atual é 100% inoperante.

## Evidência do prefixo correto (dois fatos independentes)

**1. A própria chave de homologação de AM prova o padrão de concatenação.**
`HOMOLOGACAO` = `"https://hom"` + o caminho ⇒ `homnfce.sefaz.am.gov.br`, que resolve e exige
certificado de cliente:

```
$ openssl s_client -connect homnfce.sefaz.am.gov.br:443
subject=C=BR, ST=AM, L=MANAUS, O=SECRETARIA DE ESTADO DA FAZENDA SEFAZ, CN=*.sefaz.am.gov.br
Acceptable client certificate CA names
... ssl/tls alert bad certificate ... SSL alert number 42
```

Ou seja: os caminhos são prefixados **apenas com o esquema**. Logo produção tem de ser `https://`
⇒ `nfce.sefaz.am.gov.br`, que apresenta o **mesmo certificado** e a **mesma exigência de
certificado de cliente** (alert 42) — assinatura de endpoint SOAP com mTLS, a mesma usada como
prova para o autorizador de GO no #8.

**2. `sistemas.` é comprovadamente o portal, não o autorizador.**

```
$ openssl s_client -connect sistemas.sefaz.am.gov.br:443
subject=CN=sistemas.sefaz.am.gov.br
Verify return code: 0 (ok)      # completa o handshake, sem exigir cert de cliente
```

Portal público — correto para `<qrCode>`/`<urlChave>`, errado para SOAP. É exatamente o mesmo
acidente do GO: uma chave servindo dois papéis.

## Mudança

- `NFCE["AM"]["HTTPS"]`: `"https://sistemas."` → `"https://"`, com comentário explicando que os
  caminhos já embutem o subdomínio. `HOMOLOGACAO` fica intacta (já estava correta).
- `QR_HOST` / `QR_HOST_HOMOLOGACAO` de AM seguem em `"https://sistemas."` — o `<qrCode>` e o
  `<urlChave>` de AM ficam **byte a byte idênticos**, travado por
  `tests/test_nfce_qrcode_hosts_por_uf.py` (que passa sem alteração).

## Testes

`tests/processamento/test_comunicacao_url_nfce_am.py` (novo, 5 testes): URL de autorização exata
em produção e homologação; host idêntico em `AUTORIZACAO`/`STATUS`/`EVENTOS`/`INUTILIZACAO`/
`CHAVE`/`RECIBO`; nenhuma URL de webservice pode conter `sistemas.`; chaves de QR e de webservice
distintas. **Contrafactual verificado:** com o valor antigo em memória, 4 dos 5 testes falham (o
5º é o de homologação, que já estava correto) — a trava não é vazia.

Suíte completa: **177 testes + 8 subtests**, `ruff check` e `ruff format --check` limpos.

## Correções de revisão incluídas

- `test_sp_e_am_mantem_o_host_de_qr_historico` derivava o esperado de `NFCE[uf]["HTTPS"]` — a
  trava de byte-identidade se auto-satisfazia justamente quando essa chave fosse corrigida.
  Passou a usar literais.
- `docs/webservices_map.md` / `docs/serializacao_map.md`: as âncoras de linha ficaram
  desatualizadas (o docstring de módulo do #8 deslocou todo o `webservices.py`; o mapa de
  serialização já estava ~123 linhas fora). Source map com offset errado anula o propósito do
  arquivo, então foram recalculadas contra o código real.

## Fora de escopo (registrado, não alterado)

`NFCE["MT"]` e `NFCE["CE"]` estão na lista de UFs com webservice próprio de NFC-e, mas não têm
endpoints usáveis (MT não tem nenhuma chave de webservice; CE tem todas como string vazia). Uma
emissão de NFC-e nessas UFs levanta `KeyError` / monta URL vazia antes de sair. Corrigir exige
autorar os endpoints das duas UFs, o que não é validável sem certificado dessas UFs.
