### PR TITLE
fix(nfce): urlChave e campo proprio, nao o endereco do QR Code — GO/BA/PR [DEV-2468]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,5 +119,15 @@ ruff format pynfe/
   prefixes read only by `qrcode_host` (used for `<qrCode>`/`<urlChave>`). Never make one key
   serve both roles: a webservice pointed at the consultation portal gets a redirect plus HTML
   instead of a SEFAZ verdict, so emissions fail as transport errors with no rejeicao to explain
-  them. When a UF changes its consultation host, touch only the `QR_*` keys, and when a UF's
+  them. When a UF changes its consultation host, touch only the `QR_*` keys
+- **`<qrCode>` and `<urlChave>` are separate registries; no UF uses one address for both.**
+  `urlChave` (consulta por chave de acesso) comes from `CONSULTA_CHAVE`/
+  `CONSULTA_CHAVE_HOMOLOGACAO` — the COMPLETE, verbatim URL from the official registry
+  (`URL-ConsultaNFCe_2.00` in ACBr's `ACBrNFeServicos.ini`, cross-checked against ENCAT) —
+  returned by `url_consulta_chave` with no host prefix ever concatenated onto it. GO rejects
+  878 when `urlChave` carries the QR Code address, and concatenating a host prefix onto an
+  already-complete URL is what produced values like `https://nfce.http://www.dfe.ms.gov.br/…`.
+  Source the value from the registry, never infer it from a sibling UF; details and the
+  per-UF divergence inventory are in `docs/webservices_map.md` and
+  `tests/test_nfce_urlchave_por_uf.py`, and when a UF's
   endpoint paths already embed a subdomain, the authorizer prefix is the scheme alone.

--- a/docs/serializacao_map.md
+++ b/docs/serializacao_map.md
@@ -1,4 +1,4 @@
-# Source Map: `serializacao.py` (2895 lines)
+# Source Map: `serializacao.py` (2881 lines)
 
 XML serialization of NF-e, NFC-e, NFS-e and MDF-e documents into SEFAZ-compliant XML format.
 
@@ -8,10 +8,10 @@ XML serialization of NF-e, NFC-e, NFS-e and MDF-e documents into SEFAZ-compliant
 |-------|-------|---------|
 | `Serializacao` | 31-65 | Abstract base class (not instantiable directly) |
 | `SerializacaoXML` | 67-2222 | Main NF-e/NFC-e XML serialization |
-| `SerializacaoQrcode` | 2225-2323 | NFC-e QR Code generation |
+| `SerializacaoQrcode` | 2225-2309 | NFC-e QR Code generation |
 | `SerializacaoNfse` | 2326-2392 | NFS-e serialization (Betha/Ginfes) |
-| `SerializacaoQrcodeMDFe` | 2395-2418 | MDF-e QR Code generation |
-| `SerializacaoMDFe` | 2421-2895 | MDF-e XML serialization |
+| `SerializacaoQrcodeMDFe` | 2381-2404 | MDF-e QR Code generation |
+| `SerializacaoMDFe` | 2407-2881 | MDF-e XML serialization |
 
 ---
 
@@ -102,19 +102,21 @@ Abstract base for all serializers. Stores `_fonte_dados`, `_ambiente` (1=prod, 2
 
 ---
 
-## `SerializacaoQrcode` — Lines 2225-2323
+## `SerializacaoQrcode` — Lines 2225-2309
 
-Generates NFC-e QR Code URL. Handles online/offline modes and state-specific URL patterns (SP, BA, MG, etc.).
+Generates the `<infNFeSupl>` block. `<qrCode>` handles online/offline modes and the
+state-specific host/path patterns; `<urlChave>` is a separate registry and comes straight from
+`webservices.url_consulta_chave` — never concatenate a host onto it (DEV-2468, rejeicao 878).
 
-## `SerializacaoNfse` — Lines 2326-2392
+## `SerializacaoNfse` — Lines 2312-2378
 
 Delegates to Betha or Ginfes serializers. Methods: `gerar`, `gerar_lote`, `consultar_nfse`, `consultar_lote`, `consultar_rps`, `consultar_situacao_lote`, `cancelar`.
 
-## `SerializacaoQrcodeMDFe` — Lines 2395-2418
+## `SerializacaoQrcodeMDFe` — Lines 2381-2404
 
 Generates MDF-e QR Code URL using SVRS endpoint.
 
-## `SerializacaoMDFe` — Lines 2421-2895
+## `SerializacaoMDFe` — Lines 2407-2881
 
 ### Methods
 | Method | Lines | Purpose |

--- a/docs/webservices_map.md
+++ b/docs/webservices_map.md
@@ -1,4 +1,4 @@
-# Source Map: `webservices.py` (615 lines)
+# Source Map: `webservices.py` (673 lines)
 
 SEFAZ webservice endpoint URLs organized by document type, state, and environment.
 
@@ -6,13 +6,14 @@ SEFAZ webservice endpoint URLs organized by document type, state, and environmen
 
 | Section | Lines | Variable | Purpose |
 |---------|-------|----------|---------|
-| Host roles (consulta vs autorizador) | 1-22 | — | Module docstring: which key family each consumer may read |
-| NFC-e endpoints | 24-323 | `NFCE` | NFC-e webservice URLs and QR Code URLs by state |
-| `qrcode_host` helper | 326-337 | — | Consultation-portal host prefix for `<qrCode>`/`<urlChave>` |
-| NF-e endpoints | 343-514 | `NFE` | NF-e webservice URLs by state |
-| NFS-e endpoints | 517-542 | `NFSE` | NFS-e URLs (Betha, Ginfes) |
-| MDF-e endpoints | 545-559 | `MDFE` | MDF-e URLs (SVRS only) |
-| CT-e endpoints | 561-615 | `CTE` | CT-e URLs by state |
+| Host roles + `qrCode` vs `urlChave` | 1-40 | — | Module docstring: which key family each consumer may read |
+| NFC-e endpoints | 45-359 | `NFCE` | NFC-e webservice URLs, QR Code URLs and consultation URLs by state |
+| `qrcode_host` helper | 362-375 | — | Consultation-portal host prefix for `<qrCode>` |
+| `url_consulta_chave` helper | 378-399 | — | Complete `<urlChave>` URL, never concatenated |
+| NF-e endpoints | 401-572 | `NFE` | NF-e webservice URLs by state |
+| NFS-e endpoints | 575-600 | `NFSE` | NFS-e URLs (Betha, Ginfes) |
+| MDF-e endpoints | 603-617 | `MDFE` | MDF-e URLs (SVRS only) |
+| CT-e endpoints | 619-673 | `CTE` | CT-e URLs by state |
 
 ## URL Structure
 
@@ -31,11 +32,19 @@ Each state/virtual environment entry contains:
   `<qrCode>`/`<urlChave>` (read only by `qrcode_host`); falls back to `HTTPS`/`HOMOLOGACAO`
   for UFs that serve both roles from the same host
 - `QR` — QR Code path (NFC-e only; `QR_HOMOLOGACAO` where the path differs per environment)
-- `URL` — Consultation path (NFC-e only)
+- `URL` — Legacy consultation path (NFC-e only), still read by `url_consulta_chave` as a
+  fallback for UFs that declare no `CONSULTA_CHAVE`
+- `CONSULTA_CHAVE` / `CONSULTA_CHAVE_HOMOLOGACAO` — COMPLETE, verbatim `<urlChave>` from the
+  official registry (`URL-ConsultaNFCe_2.00` in ACBr / the ENCAT listing). Returned as-is: no
+  host prefix is ever concatenated onto it. Declare this for any UF you add or fix
 
 The two host families must never be shared: a UF such as GO answers webservice POSTs sent to
 its consultation host with a load-balancer redirect and HTML, so the invoice never receives a
 SEFAZ verdict and the failure surfaces as a transport/XML-parse error, not a rejeicao.
+
+`<qrCode>` and `<urlChave>` are likewise separate registries — no UF uses the QR Code address
+as its consultation-by-key address. GO rejects 878 when they are the same. `urlChave` values
+live in `CONSULTA_CHAVE*`; `qrCode` is built from `QR*` over `qrcode_host`.
 
 ## State/Virtual Environment Groups
 
@@ -76,4 +85,5 @@ Only `SVRS` (547-558) — single authorizer for all states.
 
 | Function | Lines | Purpose |
 |----------|-------|---------|
-| `qrcode_host(uf, producao=True)` | 326-337 | Consultation-portal host prefix for `<qrCode>`/`<urlChave>`, with fallback to the webservice host |
+| `qrcode_host(uf, producao=True)` | 362-375 | Consultation-portal host prefix for `<qrCode>`, with fallback to the webservice host |
+| `url_consulta_chave(uf, producao=True)` | 378-399 | Complete `<urlChave>` URL from `CONSULTA_CHAVE*`, falling back to the legacy `URL` path |

--- a/pynfe/processamento/serializacao.py
+++ b/pynfe/processamento/serializacao.py
@@ -25,7 +25,7 @@ from pynfe.utils.flags import (
     VERSAO_PADRAO,
     VERSAO_QRCODE,
 )
-from pynfe.utils.webservices import MDFE, NFCE, qrcode_host
+from pynfe.utils.webservices import MDFE, NFCE, qrcode_host, url_consulta_chave
 
 
 class Serializacao(object):
@@ -2278,36 +2278,22 @@ class SerializacaoQrcode(object):
 
         url = "p={}|{}".format(url, url_hash)
 
-        # url_chave -Texto com a URL de consulta por chave de acesso a ser impressa no DANFE NFC-e.
-        # Informar a URL da “Consulta por chave de acesso da NFC-e”.
-        # A mesma URL que deve estar informada no DANFE NFC-e para consulta por chave de acesso
-        lista_uf_padrao = ["PR", "CE", "RS", "RJ", "RO", "DF"]
-        if uf in lista_uf_padrao:
+        # As UFs abaixo divergem apenas em COMO montar o <qrCode>: para quais delas o caminho
+        # "QR" ja embute o host, e qual caminho vale por ambiente.
+        lista_uf_qr_sem_host = ["PR", "CE", "RS", "RJ", "RO", "DF", "MG"]
+        if uf in lista_uf_qr_sem_host:
             qrcode = NFCE[uf]["QR"] + url
-            url_chave = NFCE[uf]["URL"]
-        elif uf == "SP":
-            host = qrcode_host(uf, producao=tpamb == "1")
-            qrcode = host + NFCE[uf]["QR"] + url
-            url_chave = host + NFCE[uf]["URL"]
-        # BA tem comportamento distindo para qrcode e url
-        elif uf == "BA":
-            qrcode = qrcode_host(uf, producao=tpamb == "1") + NFCE[uf]["QR"] + url
-            url_chave = NFCE[uf]["URL"]
-        # MG tem comportamento distintos para qrcode e url
-        elif uf == "MG":
-            qrcode = NFCE[uf]["QR"] + url
-            url_chave = qrcode_host(uf, producao=tpamb == "1") + NFCE[uf]["URL"]
-        # AM tem comportamento distintos para qrcode e url
         elif uf == "AM":
-            host = qrcode_host(uf, producao=tpamb == "1")
             caminho_qr = NFCE[uf]["QR"] if tpamb == "1" else NFCE[uf]["QR_HOMOLOGACAO"]
-            qrcode = host + caminho_qr + url
-            url_chave = host + NFCE[uf]["URL"]
-        # AC, RR, PA, SE, GO
+            qrcode = qrcode_host(uf, producao=tpamb == "1") + caminho_qr + url
+        # AC, AP, BA, ES, GO, MS, PA, PE, RR, SC, SE, SP
         else:
-            host = qrcode_host(uf, producao=tpamb == "1")
-            qrcode = host + NFCE[uf]["QR"] + url
-            url_chave = host + NFCE[uf]["URL"]
+            qrcode = qrcode_host(uf, producao=tpamb == "1") + NFCE[uf]["QR"] + url
+
+        # <urlChave> e a URL da "Consulta por chave de acesso da NFC-e" impressa no DANFE
+        # NFC-e - registro oficial DIFERENTE do endereco do QR Code. url_consulta_chave
+        # devolve o valor completo; nunca concatene host aqui (DEV-2468).
+        url_chave = url_consulta_chave(uf, producao=tpamb == "1")
         # adicionta tag infNFeSupl com qrcode
         info = etree.Element("infNFeSupl")
         etree.SubElement(info, "qrCode").text = etree.CDATA(qrcode.strip())

--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -16,6 +16,27 @@ uma pela outra:
 Apontar webservice para o host de consulta nao gera rejeicao: o portal responde
 redirect + HTML, entao a nota nunca recebe veredito da SEFAZ. Ao atualizar o host de
 consulta de uma UF, mexa somente nas chaves ``QR_*``.
+
+``qrCode`` vs ``urlChave``
+-------------------------
+Sao dois campos do ``<infNFeSupl>`` com registros oficiais DIFERENTES, e nenhuma UF
+usa o mesmo endereco nos dois:
+
+- ``<qrCode>``: endereco do leitor de QR Code (``QR``/``QR_HOMOLOGACAO`` sobre
+  ``qrcode_host``).
+- ``<urlChave>``: endereco da "Consulta por chave de acesso" (``URL-ConsultaNFCe_2.00``
+  no registro do ACBr / ENCAT), lido por ``url_consulta_chave``.
+
+Para o ``urlChave`` a chave dedicada e ``CONSULTA_CHAVE`` /
+``CONSULTA_CHAVE_HOMOLOGACAO``, que guarda a URL COMPLETA e VERBATIM do registro -
+inclusive o esquema quando o registro o traz, e sem esquema quando nao traz. Nenhum
+prefixo de host e concatenado nesse valor: foi exatamente essa concatenacao sobre uma
+URL ja completa que produziu lixo como ``https://nfce.http://www.dfe.ms.gov.br/...``
+nas UFs que ainda dependem do caminho legado ``URL``. Ao registrar uma UF nova,
+declare ``CONSULTA_CHAVE`` em vez de mexer em ``URL``.
+
+Usar o endereco de QR Code no ``urlChave`` gera rejeicao 878 em GO ("Endereco do site
+da UF da Consulta por chave de acesso diverge do previsto") - DEV-2468.
 """
 
 # http://nfce.encat.org/desenvolvedor/qrcode/
@@ -176,6 +197,10 @@ NFCE = {
         "HTTPS": "http://nfe.",
         "HOMOLOGACAO": "http://hnfe.",
         "URL": "http://hinternet.sefaz.ba.gov.br/nfce/consulta",
+        # ACBrNFeServicos.ini [NFCe_BA_P]/[NFCe_BA_H] URL-ConsultaNFCe_2.00. O "URL" acima
+        # era o valor de homologacao, emitido tambem em producao.
+        "CONSULTA_CHAVE": "http://www.sefaz.ba.gov.br/nfce/consulta",
+        "CONSULTA_CHAVE_HOMOLOGACAO": "http://hinternet.sefaz.ba.gov.br/nfce/consulta",
     },
     "MG": {
         "STATUS": "fazenda.mg.gov.br/nfce/services/NFeStatusServico4",
@@ -243,6 +268,10 @@ NFCE = {
         "CADASTRO": "nfce.sefa.pr.gov.br/nfce/CadConsultaCadastro4?wsdl",
         "QR": "http://www.fazenda.pr.gov.br/nfce/qrcode?",
         "URL": "http://www.fazenda.pr.gov.br/nfce/consulta",
+        # ACBrNFeServicos.ini [NFCe_PR_P]/[NFCe_PR_H] URL-ConsultaNFCe_2.00 - mesmo valor nos
+        # dois ambientes, byte-identico ao que o caminho legado ja emitia.
+        "CONSULTA_CHAVE": "http://www.fazenda.pr.gov.br/nfce/consulta",
+        "CONSULTA_CHAVE_HOMOLOGACAO": "http://www.fazenda.pr.gov.br/nfce/consulta",
         "HTTPS": "https://",
         "HOMOLOGACAO": "https://homologacao.",
     },
@@ -303,6 +332,13 @@ NFCE = {
         "QR_HOST": "https://nfeweb.",
         "QR_HOST_HOMOLOGACAO": "https://nfewebhomolog.",
         "URL": "sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe",
+        # ACBrNFeServicos.ini [NFCe_GO_P]/[NFCe_GO_H] URL-ConsultaNFCe_2.00, confirmado pelo
+        # registro ENCAT. O IT 2025.003 definiu somente a URL do QR Code, por isso o "URL"
+        # acima ficou apontando para o leitor de QR e GO passou a rejeitar 878.
+        "CONSULTA_CHAVE": "http://www.sefaz.go.gov.br/nfce/consulta",
+        "CONSULTA_CHAVE_HOMOLOGACAO": (
+            "http://www.nfce.go.gov.br/post/ver/214413/consulta-nfc-e-homologacao"
+        ),
     },
     "DF": {
         "QR": "http://www.fazenda.df.gov.br/nfce/qrcode?",
@@ -335,6 +371,28 @@ def qrcode_host(uf, producao=True):
     if dados.get(chave_qr):
         return dados[chave_qr]
     return dados["HTTPS"] if producao else dados["HOMOLOGACAO"]
+
+
+# UFs cujo ``URL`` legado ja e a urlChave completa, sem prefixo de host. Lista fechada:
+# UFs novas devem declarar ``CONSULTA_CHAVE`` em vez de entrar aqui.
+UFS_URLCHAVE_SEM_HOST = frozenset({"CE", "DF", "RJ", "RO", "RS"})
+
+
+def url_consulta_chave(uf, producao=True):
+    """URL completa de consulta por chave de acesso, para o ``<urlChave>``.
+
+    Prefere ``CONSULTA_CHAVE``/``CONSULTA_CHAVE_HOMOLOGACAO``, que guardam o valor
+    verbatim do registro oficial e sao devolvidos sem nenhuma concatenacao. Sem essas
+    chaves, reproduz o caminho legado (``URL``, com prefixo de host onde a UF nunca
+    declarou host no proprio ``URL``).
+    """
+    dados = NFCE[uf]
+    chave = "CONSULTA_CHAVE" if producao else "CONSULTA_CHAVE_HOMOLOGACAO"
+    if dados.get(chave):
+        return dados[chave]
+    if uf in UFS_URLCHAVE_SEM_HOST:
+        return dados["URL"]
+    return qrcode_host(uf, producao=producao) + dados["URL"]
 
 
 # Nfe

--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -360,11 +360,14 @@ NFCE = {
 
 
 def qrcode_host(uf, producao=True):
-    """Prefixo de host do portal de consulta usado no ``<qrCode>``/``<urlChave>``.
+    """Prefixo de host do portal de consulta usado no ``<qrCode>``.
 
     Prefere as chaves dedicadas ``QR_HOST``/``QR_HOST_HOMOLOGACAO``; para UFs que nao
     declaram host de consulta proprio (portal e autorizador no mesmo servidor), cai no
     host de webservice, preservando o comportamento historico.
+
+    Nao serve o ``<urlChave>``: esse campo tem registro proprio e URL completa, ver
+    ``url_consulta_chave``.
     """
     dados = NFCE[uf]
     chave_qr = "QR_HOST" if producao else "QR_HOST_HOMOLOGACAO"

--- a/tests/processamento/test_comunicacao_url_nfce_am.py
+++ b/tests/processamento/test_comunicacao_url_nfce_am.py
@@ -16,7 +16,7 @@ facts settle the correct prefix:
   the same certificate and the same client-certificate demand.
 - ``sistemas.sefaz.am.gov.br`` completes the TLS handshake with no client certificate and a
   plain ``CN=sistemas.sefaz.am.gov.br`` cert — it is the public portal, correct for
-  ``<qrCode>``/``<urlChave>`` and wrong for SOAP.
+  ``<qrCode>`` and wrong for SOAP.
 
 The QR host stays on ``https://sistemas.`` via ``QR_HOST``; the byte-identity of AM's
 ``<qrCode>``/``<urlChave>`` is locked in ``tests/test_nfce_qrcode_hosts_por_uf.py``.

--- a/tests/processamento/test_comunicacao_url_nfce_go.py
+++ b/tests/processamento/test_comunicacao_url_nfce_go.py
@@ -3,7 +3,7 @@
 """Regression tests for the GO NFC-e WEBSERVICE host (autorizador, not consulta portal).
 
 GO serves the public consultation portal (``nfeweb.sefaz.go.gov.br``, destination of
-``<qrCode>``/``<urlChave>``) and the SOAP authorizer (``nfe.sefaz.go.gov.br``) from
+``<qrCode>``) and the SOAP authorizer (``nfe.sefaz.go.gov.br``) from
 different hosts. Pointing the webservice URL at the consultation portal does NOT produce
 a SEFAZ rejeicao: the portal answers a BigIP redirect plus HTML, so the invoice never gets
 a verdict at all and every emission fails as a transport error. These tests pin the

--- a/tests/test_nfce_qrcode_go.py
+++ b/tests/test_nfce_qrcode_go.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 # *-* encoding: utf8 *-*
-"""Regression tests for the Goias (GO) NFC-e QRCode/urlChave host.
+"""Regression tests for the Goias (GO) NFC-e ``<qrCode>`` host.
 
-Informe Tecnico 2025.003 moved the GO NFC-e consultation host from the old
+Informe Tecnico 2025.003 moved the GO NFC-e QR Code host from the old
 ``nfe.sefaz.go.gov.br`` / ``homolog.sefaz.go.gov.br`` subdomains to
 ``nfeweb.sefaz.go.gov.br`` (producao) and ``nfewebhomolog.sefaz.go.gov.br``
 (homologacao). Emitting with the old host triggers SEFAZ rejeicao 395
-("Informado QR-Code para NFC-e com formato invalido"). These tests pin both
-the ``<qrCode>`` base and the ``<urlChave>`` so the host can never silently
-regress to the rejected subdomain again. See DEV-2177.
+("Informado QR-Code para NFC-e com formato invalido"). These tests pin the
+``<qrCode>`` base so the host can never silently regress to the rejected
+subdomain again. See DEV-2177.
+
+The ``<urlChave>`` is deliberately NOT asserted against this host: IT 2025.003
+defines only the QR Code address, and emitting it as ``urlChave`` is what made GO
+reject 878. That field has its own registry and its own tests in
+``test_nfce_urlchave_por_uf.py`` (DEV-2468).
 """
 
 import unittest
@@ -64,31 +69,21 @@ class QrcodeGoNFCeTestCase(unittest.TestCase):
         return qrcode, url_chave
 
     def test_qrcode_producao_usa_host_nfeweb(self):
-        qrcode, url_chave = self._gerar(TP_AMB_PRODUCAO)
+        qrcode, _ = self._gerar(TP_AMB_PRODUCAO)
         self.assertTrue(
             qrcode.startswith(QRCODE_HOST_PRODUCAO),
             f"qrCode de producao deve comecar com {QRCODE_HOST_PRODUCAO}, veio: {qrcode}",
         )
-        self.assertTrue(
-            url_chave.startswith(QRCODE_HOST_PRODUCAO),
-            f"urlChave de producao deve comecar com {QRCODE_HOST_PRODUCAO}, veio: {url_chave}",
-        )
         # Garante que nao reverteu para o subdominio rejeitado (rejeicao 395).
         self.assertNotIn("https://nfe.sefaz.go.gov.br", qrcode)
-        self.assertNotIn("https://nfe.sefaz.go.gov.br", url_chave)
 
     def test_qrcode_homologacao_usa_host_nfewebhomolog(self):
-        qrcode, url_chave = self._gerar(TP_AMB_HOMOLOGACAO)
+        qrcode, _ = self._gerar(TP_AMB_HOMOLOGACAO)
         self.assertTrue(
             qrcode.startswith(QRCODE_HOST_HOMOLOGACAO),
             f"qrCode de homologacao deve comecar com {QRCODE_HOST_HOMOLOGACAO}, veio: {qrcode}",
         )
-        self.assertTrue(
-            url_chave.startswith(QRCODE_HOST_HOMOLOGACAO),
-            f"urlChave de homologacao deve comecar com {QRCODE_HOST_HOMOLOGACAO}, veio: {url_chave}",
-        )
         self.assertNotIn("https://homolog.sefaz.go.gov.br", qrcode)
-        self.assertNotIn("https://homolog.sefaz.go.gov.br", url_chave)
 
 
 if __name__ == "__main__":

--- a/tests/test_nfce_qrcode_hosts_por_uf.py
+++ b/tests/test_nfce_qrcode_hosts_por_uf.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 # *-* encoding: utf8 *-*
-"""Pins the ``<qrCode>``/``<urlChave>`` host of every UF whose branch reads a host prefix.
+"""Pins the ``<qrCode>`` host of every UF whose branch reads a host prefix.
 
 The GO fix (DEV-2468) routed those branches through ``webservices.qrcode_host`` so the QR
 host can no longer be taken from the authorizer keys. These tests lock the resulting URLs
 for SP, AM, BA and MG in both environments, which is what makes the refactor verifiable as
 byte-identical outside GO.
+
+``urlChave`` is asserted here only as the value that pairs with each of those QR hosts; the
+field's own registry, property tests and non-regression set live in
+``test_nfce_urlchave_por_uf.py``.
 """
 
 import unittest

--- a/tests/test_nfce_qrcode_hosts_por_uf.py
+++ b/tests/test_nfce_qrcode_hosts_por_uf.py
@@ -44,7 +44,9 @@ ESPERADO = {
     "BA": {
         TP_AMB_PRODUCAO: (
             "http://nfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx?",
-            "http://hinternet.sefaz.ba.gov.br/nfce/consulta",
+            # ACBr [NFCe_BA_P] URL-ConsultaNFCe_2.00; o hinternet e o valor de homologacao,
+            # emitido em producao ate DEV-2468.
+            "http://www.sefaz.ba.gov.br/nfce/consulta",
         ),
         TP_AMB_HOMOLOGACAO: (
             "http://hnfe.sefaz.ba.gov.br/servicos/nfce/qrcode.aspx?",

--- a/tests/test_nfce_urlchave_por_uf.py
+++ b/tests/test_nfce_urlchave_por_uf.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# *-* encoding: utf8 *-*
+"""Pins the ``<urlChave>`` of every UF that can emit NFC-e.
+
+``<qrCode>`` and ``<urlChave>`` are different fields with different official registries.
+GO rejects 878 ("Endereco do site da UF da Consulta por chave de acesso diverge do
+previsto") when the QR Code address is emitted as ``urlChave`` - which is what PyNFe did
+for GO until DEV-2468, because IT 2025.003 only ever defined the QR Code URL.
+
+Reference values come from the ACBr registry
+(``ACBrNFeServicos.ini``, ``URL-ConsultaNFCe_2.00`` of ``[NFCe_<UF>_P]`` / ``[NFCe_<UF>_H]``),
+cross-checked against the ENCAT listing for GO. The corrupted/outdated UFs left untouched in
+this round are inventoried in
+``docs/issues/followup-dev-2468-urlchave-ufs-sem-loja.md`` of the workspace repo, and pinned
+here as exact sets so a NEW corruption fails the suite and fixing an old one forces the list
+to shrink.
+"""
+
+import unittest
+
+from lxml import etree
+
+from pynfe.processamento.serializacao import SerializacaoQrcode
+from pynfe.utils.flags import CODIGOS_ESTADOS, NAMESPACE_NFE, NAMESPACE_SIG
+from pynfe.utils.webservices import NFCE, url_consulta_chave
+
+TP_AMB_PRODUCAO = "1"
+TP_AMB_HOMOLOGACAO = "2"
+
+# UFs corrigidas nesta rodada: valor verbatim do registro, por ambiente.
+CORRIGIDAS = {
+    "GO": {
+        TP_AMB_PRODUCAO: "http://www.sefaz.go.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: (
+            "http://www.nfce.go.gov.br/post/ver/214413/consulta-nfc-e-homologacao"
+        ),
+    },
+    "BA": {
+        TP_AMB_PRODUCAO: "http://www.sefaz.ba.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: "http://hinternet.sefaz.ba.gov.br/nfce/consulta",
+    },
+    "PR": {
+        TP_AMB_PRODUCAO: "http://www.fazenda.pr.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: "http://www.fazenda.pr.gov.br/nfce/consulta",
+    },
+}
+
+# UFs que ja batiam com o registro e nao podem mudar um byte. RJ carrega a maior parte da
+# frota, entao e a nao-regressao mais importante do arquivo.
+NAO_REGRESSAO = {
+    "RJ": {
+        TP_AMB_PRODUCAO: "www.fazenda.rj.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: "www.fazenda.rj.gov.br/nfce/consulta",
+    },
+    "AC": {
+        TP_AMB_PRODUCAO: "http://www.sefaznet.ac.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: "http://hml.sefaznet.ac.gov.br/nfce/consulta",
+    },
+    "DF": {
+        TP_AMB_PRODUCAO: "www.fazenda.df.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: "www.fazenda.df.gov.br/nfce/consulta",
+    },
+    "PE": {
+        TP_AMB_PRODUCAO: "http://nfce.sefaz.pe.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: "http://nfcehomolog.sefaz.pe.gov.br/nfce/consulta",
+    },
+    "SC": {
+        TP_AMB_PRODUCAO: "https://sat.sef.sc.gov.br/nfce/consulta",
+        TP_AMB_HOMOLOGACAO: "https://hom.sat.sef.sc.gov.br/nfce/consulta",
+    },
+}
+
+# UFs sem endereco de consulta cadastrado: nao emitem NFC-e por este fork.
+UFS_SEM_URLCHAVE = frozenset({"AL", "MA", "MT", "PB", "PI", "RN", "TO"})
+
+# Divergencias conhecidas e deliberadamente NAO corrigidas (sem loja para validar).
+# "http" repetido = prefixo de host concatenado sobre uma URL que ja tinha esquema.
+UFS_URLCHAVE_COM_ESQUEMA_DUPLICADO = frozenset({"AP", "MS"})
+# ".www." no meio do host = prefixo de host concatenado sobre um hostname completo.
+UFS_URLCHAVE_COM_HOST_DUPLICADO = frozenset({"ES"})
+# UFs em que o registro oficial usa o MESMO endereco para consulta e QR Code (SC: o proprio
+# ACBr registra sat.sef.sc.gov.br/nfce/consulta nos dois) ou em que o valor legado ainda
+# aponta para o leitor de QR (RS, pendente de correcao).
+UFS_URLCHAVE_IGUAL_AO_QRCODE = frozenset({"RS", "SC"})
+
+UFS_EMISSORAS = sorted(set(NFCE) - {"SVRS"} - UFS_SEM_URLCHAVE)
+
+
+def _nfe(uf, tp_amb):
+    cuf = CODIGOS_ESTADOS[uf]
+    chave = cuf + "0" * 42
+    xml = (
+        f'<NFe xmlns="{NAMESPACE_NFE}">'
+        f'<infNFe Id="NFe{chave}">'
+        f"<ide><cUF>{cuf}</cUF><dhEmi>2025-01-14T12:00:00-03:00</dhEmi>"
+        f"<tpAmb>{tp_amb}</tpAmb></ide>"
+        f"<dest><CPF>12345678900</CPF></dest>"
+        f"<total><ICMSTot><vNF>10.00</vNF></ICMSTot></total>"
+        f"</infNFe>"
+        f'<Signature xmlns="{NAMESPACE_SIG}"><SignedInfo><Reference>'
+        f"<DigestValue>ABCDEF==</DigestValue>"
+        f"</Reference></SignedInfo></Signature>"
+        f"</NFe>"
+    )
+    return etree.fromstring(xml.encode())
+
+
+def _emitir(uf, tp_amb):
+    nfe, qrcode = SerializacaoQrcode().gerar_qrcode(
+        "000001", "CSC123", _nfe(uf, tp_amb), return_qr=True
+    )
+    return qrcode, nfe.find("infNFeSupl").find("urlChave").text
+
+
+class UrlChaveRegistroTestCase(unittest.TestCase):
+    def test_ufs_corrigidas_emitem_valor_do_registro(self):
+        for uf, ambientes in CORRIGIDAS.items():
+            for tp_amb, esperado in ambientes.items():
+                with self.subTest(uf=uf, tpAmb=tp_amb):
+                    _, url_chave = _emitir(uf, tp_amb)
+                    self.assertEqual(url_chave, esperado)
+
+    def test_ufs_ja_corretas_nao_mudam(self):
+        for uf, ambientes in NAO_REGRESSAO.items():
+            for tp_amb, esperado in ambientes.items():
+                with self.subTest(uf=uf, tpAmb=tp_amb):
+                    _, url_chave = _emitir(uf, tp_amb)
+                    self.assertEqual(url_chave, esperado)
+
+    def test_qrcode_de_go_continua_no_portal_do_it_2025_003(self):
+        """A correcao do urlChave nao pode arrastar o qrCode (DEV-2177/IT 2025.003)."""
+        qrcode, _ = _emitir("GO", TP_AMB_PRODUCAO)
+        self.assertTrue(
+            qrcode.startswith("https://nfeweb.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe?"),
+            f"qrCode de GO regrediu: {qrcode}",
+        )
+        qrcode_hom, _ = _emitir("GO", TP_AMB_HOMOLOGACAO)
+        self.assertTrue(
+            qrcode_hom.startswith(
+                "https://nfewebhomolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe?"
+            ),
+            f"qrCode de GO em homologacao regrediu: {qrcode_hom}",
+        )
+
+    def test_ufs_sem_endereco_de_consulta_nao_emitem(self):
+        for uf in sorted(UFS_SEM_URLCHAVE):
+            with self.subTest(uf=uf):
+                with self.assertRaises(KeyError):
+                    url_consulta_chave(uf, producao=True)
+
+
+class UrlChaveIntegridadeTestCase(unittest.TestCase):
+    """Propriedades que valem para a tabela inteira, nao so para as UFs desta rodada."""
+
+    def test_urlchave_nunca_tem_esquema_concatenado(self):
+        encontradas = set()
+        for uf in UFS_EMISSORAS:
+            for tp_amb in (TP_AMB_PRODUCAO, TP_AMB_HOMOLOGACAO):
+                _, url_chave = _emitir(uf, tp_amb)
+                if url_chave.count("http") > 1:
+                    encontradas.add(uf)
+        self.assertEqual(
+            encontradas,
+            set(UFS_URLCHAVE_COM_ESQUEMA_DUPLICADO),
+            "conjunto de UFs com esquema duplicado no urlChave mudou; corrija a UF ou "
+            "atualize UFS_URLCHAVE_COM_ESQUEMA_DUPLICADO",
+        )
+
+    def test_urlchave_nunca_tem_host_concatenado(self):
+        encontradas = set()
+        for uf in UFS_EMISSORAS:
+            for tp_amb in (TP_AMB_PRODUCAO, TP_AMB_HOMOLOGACAO):
+                _, url_chave = _emitir(uf, tp_amb)
+                host = url_chave.split("://")[-1].split("/")[0]
+                if ".www." in host:
+                    encontradas.add(uf)
+        self.assertEqual(
+            encontradas,
+            set(UFS_URLCHAVE_COM_HOST_DUPLICADO),
+            "conjunto de UFs com host duplicado no urlChave mudou; corrija a UF ou "
+            "atualize UFS_URLCHAVE_COM_HOST_DUPLICADO",
+        )
+
+    def test_urlchave_nao_e_o_endereco_do_qrcode(self):
+        encontradas = set()
+        for uf in UFS_EMISSORAS:
+            for tp_amb in (TP_AMB_PRODUCAO, TP_AMB_HOMOLOGACAO):
+                qrcode, url_chave = _emitir(uf, tp_amb)
+                base_qr = qrcode.split("?")[0]
+                self.assertNotEqual(qrcode, url_chave, f"{uf}/{tp_amb}")
+                if base_qr == url_chave:
+                    encontradas.add(uf)
+        self.assertEqual(
+            encontradas,
+            set(UFS_URLCHAVE_IGUAL_AO_QRCODE),
+            "conjunto de UFs cujo urlChave repete o endereco do qrCode mudou; foi "
+            "exatamente esse defeito que gerou a rejeicao 878 em GO",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

`<qrCode>` e `<urlChave>` sao campos diferentes do `<infNFeSupl>`, com registros oficiais
diferentes. O PyNFe montava os dois com a mesma familia host+path
(`qrcode_host(uf) + NFCE[uf]["URL"]`), entao o `urlChave` saia com o endereco do leitor de
QR Code.

GO valida esse campo. Medido em producao em 12/08: **121 cupons com `cstat = 878`** entre
17:16 e 17:23 na loja 394 (Bolina, unica loja de GO), todos `tp_emissao = 9`, vendas de
23/06 a 12/08 — `Rejeicao: Endereco do site da UF da Consulta por chave de acesso diverge do
previsto`.

XML transmitido (cupom 11997515, lido do storage de producao):

```xml
<infNFeSupl>
  <qrCode><![CDATA[https://nfeweb.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe?p=...]]></qrCode>
  <urlChave>https://nfeweb.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe</urlChave>
</infNFeSupl>
```

O `qrCode` esta **correto** — e o endereco do IT 2025.003, corrigido no DEV-2177. O `urlChave`
nao. O IT 2025.003 define **somente** a URL do QR Code e nunca fala de `urlChave`; foi por isso
que a rodada anterior (host de webservice, PRs #8 e #9) acertou o QR e nao percebeu o outro
campo.

## Fontes que fixam o valor

Duas independentes, concordantes:

1. `ACBrNFeServicos.ini` do projeto ACBr, `URL-ConsultaNFCe_2.00` das secoes `[NFCe_<UF>_P]` /
   `[NFCe_<UF>_H]`. Para GO: `http://www.sefaz.go.gov.br/nfce/consulta` (producao) e
   `http://www.nfce.go.gov.br/post/ver/214413/consulta-nfc-e-homologacao` (homologacao).
2. Registro ENCAT (`nfce.encat.org`, "consulte sua nota QR Code versao 2.0"), que lista
   `www.sefaz.go.gov.br/nfce/consulta` para GO.

Nenhum valor foi inferido: todos vieram do `.ini`, citado no comentario de cada chave.

## O que muda

`CONSULTA_CHAVE` / `CONSULTA_CHAVE_HOMOLOGACAO` passam a guardar a URL **completa e verbatim**
do registro (com esquema quando o registro traz, sem esquema quando nao traz), lidas por
`url_consulta_chave`. O valor e devolvido como esta — **nenhum prefixo de host e concatenado**.
Essa concatenacao sobre URLs ja completas era a causa de lixo como
`https://nfce.http://www.dfe.ms.gov.br/nfce/consulta`, e agora e impossivel por construcao:
`gerar_qrcode` tem um unico ponto de montagem do `urlChave`, sem host, e as ramificacoes por UF
ficaram restritas ao `<qrCode>`.

UFs corrigidas — so as tres com loja ativa:

| UF | Antes | Agora (producao) |
|----|-------|------------------|
| GO | `https://nfeweb.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe` | `http://www.sefaz.go.gov.br/nfce/consulta` |
| BA | `http://hinternet.sefaz.ba.gov.br/nfce/consulta` | `http://www.sefaz.ba.gov.br/nfce/consulta` |
| PR | `http://www.fazenda.pr.gov.br/nfce/consulta` | igual — byte-identico |

Duas correcoes ao diagnostico inicial, verificadas rodando o codigo:

- **PR ja estava certo.** Estava na `lista_uf_padrao`, que emitia `URL` sem prefixo de host,
  logo o valor emitido ja era o do ACBr. A mudanca em PR e declarativa (mover para a chave
  dedicada, para nao voltar a depender do caminho legado) e a saida nao muda um byte.
- **BA nao estava corrompido por concatenacao.** O defeito e mais sutil: `NFCE["BA"]["URL"]`
  guardava o valor de **homologacao** do ACBr (`[NFCe_BA_H]`, `hinternet`), emitido tambem em
  producao.

## Escopo: por que so GO, BA e PR

As outras 11 UFs divergentes (AP, ES, MS, RS, AM, CE, MG, PA, RO, RR, SE) ficam como estao.
Nao temos loja em nenhuma delas, nao ha nota real para validar a correcao contra a autorizadora,
e mudar valor fiscal de um estado sem loja para testar e risco sem retorno. O inventario
completo — separando "corrompido por concatenacao" (AP, ES, MS) de "apenas desatualizado" — e as
perguntas em aberto ficaram em control file no workspace, nao no fork.

Nao mudam um byte: **RJ** (`www.fazenda.rj.gov.br/nfce/consulta`, 229 lojas emitindo hoje), AC,
DF, PE, SC. Todos pinados em teste.

## Verificacao

Suite inteira: **184 passed, 31 subtests**. `ruff check` e `ruff format --check` limpos.

Novo `tests/test_nfce_urlchave_por_uf.py`:

- `urlChave` de GO/BA/PR igual a string do registro, em producao e homologacao;
- nao-regressao byte-identica de RJ, AC, DF, PE, SC;
- propriedade sobre a tabela inteira: nenhuma UF ganha esquema concatenado (`http` duas vezes)
  nem host concatenado (`.www.` no host) — codificado como conjunto **exato** (`{AP, MS}` e
  `{ES}`), entao o teste falha tanto se uma UF nova quebrar quanto se alguem corrigir uma sem
  atualizar a lista;
- `urlChave` nunca repete o endereco do `qrCode`, tambem como conjunto exato `{RS, SC}` — note
  que a igualdade **nao** e defeito por si: o proprio ACBr registra o mesmo endereco nos dois
  campos para SC. Em GO era, porque o registro preve outro valor;
- `<qrCode>` de GO continua em `nfeweb.sefaz.go.gov.br` nos dois ambientes (protege
  DEV-2177 / IT 2025.003).

Cada teste novo foi verificado **falhando** com a correcao revertida (falha em GO/BA e na
propriedade de igualdade com o `qrCode`). Os guards de host de webservice das PRs #8/#9 seguem
verdes.

`tests/test_nfce_qrcode_go.py` deixou de assertar o `urlChave` contra o host do QR Code: era
exatamente o acoplamento que gerou a 878. Aquele arquivo cobre o `<qrCode>`; o `urlChave` tem
arquivo proprio.

## Extend-First Gate

Nenhuma estrutura nova: `CONSULTA_CHAVE*` sao chaves dentro do dicionario `NFCE` que ja existe,
ao lado de `QR`/`QR_HOST`/`URL`, e `url_consulta_chave` e irmao de `qrcode_host` no mesmo modulo.
Nao ha modelo, app, FeatureCode, tela nem canal de sync envolvido.

## Nao incluido de proposito

- Bump do pin no `api` — etapa 2/2, depois do merge desta PR.
- Destravar/reemitir os 121 cupons ja rejeitados — decisao operacional do Suporte.
- Host de webservice (`HTTPS`/`HOMOLOGACAO`) e chaves `QR_HOST*` — corrigidos e verificados em
  producao, intocados aqui.
