### PR TITLE
docs(nfce): corrige regra falsa de urlChave e source maps do DEV-2468 [DEV-2468]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,14 @@ This allows you to navigate directly to the specific line-window you need instea
 
 | Source Map | File | Lines | Description |
 |------------|------|-------|-------------|
-| `docs/serializacao_map.md` | `pynfe/processamento/serializacao.py` | 2895 | XML serialization (NF-e, MDF-e, QR codes) |
+| `docs/serializacao_map.md` | `pynfe/processamento/serializacao.py` | 2881 | XML serialization (NF-e, MDF-e, QR codes) |
 | `docs/comunicacao_map.md` | `pynfe/processamento/comunicacao.py` | 1348 | SEFAZ webservice communication |
 | `docs/autorizador_nfse_map.md` | `pynfe/processamento/autorizador_nfse.py` | 538 | NFS-e authorization (Betha/Ginfes) |
 | `docs/notafiscal_map.md` | `pynfe/entidades/notafiscal.py` | 1253 | Invoice entities and tax fields |
 | `docs/manifesto_map.md` | `pynfe/entidades/manifesto.py` | 447 | MDF-e manifest entities |
 | `docs/evento_map.md` | `pynfe/entidades/evento.py` | 237 | Event entities (cancel, correction, etc.) |
 | `docs/flags_map.md` | `pynfe/utils/flags.py` | 645 | Constants, namespaces, tax codes |
-| `docs/webservices_map.md` | `pynfe/utils/webservices.py` | 615 | SEFAZ endpoint URLs by state |
+| `docs/webservices_map.md` | `pynfe/utils/webservices.py` | 684 | SEFAZ endpoint URLs by state |
 | `docs/utils_map.md` | `pynfe/utils/__init__.py` | 253 | Utility functions (municipality lookup, signing) |
 
 ### How to Use Source Maps
@@ -120,14 +120,15 @@ ruff format pynfe/
   serve both roles: a webservice pointed at the consultation portal gets a redirect plus HTML
   instead of a SEFAZ verdict, so emissions fail as transport errors with no rejeicao to explain
   them. When a UF changes its consultation host, touch only the `QR_*` keys
-- **`<qrCode>` and `<urlChave>` are separate registries; no UF uses one address for both.**
+- **`<qrCode>` and `<urlChave>` are separate registry entries; each is sourced on its own.**
   `urlChave` (consulta por chave de acesso) comes from `CONSULTA_CHAVE`/
   `CONSULTA_CHAVE_HOMOLOGACAO` — the COMPLETE, verbatim URL from the official registry
   (`URL-ConsultaNFCe_2.00` in ACBr's `ACBrNFeServicos.ini`, cross-checked against ENCAT) —
   returned by `url_consulta_chave` with no host prefix ever concatenated onto it. GO rejects
   878 when `urlChave` carries the QR Code address, and concatenating a host prefix onto an
   already-complete URL is what produced values like `https://nfce.http://www.dfe.ms.gov.br/…`.
-  Source the value from the registry, never infer it from a sibling UF; details and the
-  per-UF divergence inventory are in `docs/webservices_map.md` and
-  `tests/test_nfce_urlchave_por_uf.py`, and when a UF's
-  endpoint paths already embed a subdomain, the authorizer prefix is the scheme alone.
+  Source each field from its own registry entry, never from the sibling field and never from a
+  sibling UF — a few UFs legitimately register the same address for both, so equality is not by
+  itself the defect. Per-UF detail and the closed sets of known divergences live in
+  `docs/webservices_map.md` and `tests/test_nfce_urlchave_por_uf.py`. When a UF's endpoint paths
+  already embed a subdomain, the authorizer prefix is the scheme alone.

--- a/docs/serializacao_map.md
+++ b/docs/serializacao_map.md
@@ -9,7 +9,7 @@ XML serialization of NF-e, NFC-e, NFS-e and MDF-e documents into SEFAZ-compliant
 | `Serializacao` | 31-65 | Abstract base class (not instantiable directly) |
 | `SerializacaoXML` | 67-2222 | Main NF-e/NFC-e XML serialization |
 | `SerializacaoQrcode` | 2225-2309 | NFC-e QR Code generation |
-| `SerializacaoNfse` | 2326-2392 | NFS-e serialization (Betha/Ginfes) |
+| `SerializacaoNfse` | 2312-2378 | NFS-e serialization (Betha/Ginfes) |
 | `SerializacaoQrcodeMDFe` | 2381-2404 | MDF-e QR Code generation |
 | `SerializacaoMDFe` | 2407-2881 | MDF-e XML serialization |
 

--- a/docs/webservices_map.md
+++ b/docs/webservices_map.md
@@ -1,4 +1,4 @@
-# Source Map: `webservices.py` (673 lines)
+# Source Map: `webservices.py` (684 lines)
 
 SEFAZ webservice endpoint URLs organized by document type, state, and environment.
 
@@ -6,14 +6,14 @@ SEFAZ webservice endpoint URLs organized by document type, state, and environmen
 
 | Section | Lines | Variable | Purpose |
 |---------|-------|----------|---------|
-| Host roles + `qrCode` vs `urlChave` | 1-40 | — | Module docstring: which key family each consumer may read |
-| NFC-e endpoints | 45-359 | `NFCE` | NFC-e webservice URLs, QR Code URLs and consultation URLs by state |
-| `qrcode_host` helper | 362-375 | — | Consultation-portal host prefix for `<qrCode>` |
-| `url_consulta_chave` helper | 378-399 | — | Complete `<urlChave>` URL, never concatenated |
-| NF-e endpoints | 401-572 | `NFE` | NF-e webservice URLs by state |
-| NFS-e endpoints | 575-600 | `NFSE` | NFS-e URLs (Betha, Ginfes) |
-| MDF-e endpoints | 603-617 | `MDFE` | MDF-e URLs (SVRS only) |
-| CT-e endpoints | 619-673 | `CTE` | CT-e URLs by state |
+| Host roles + `qrCode` vs `urlChave` | 1-44 | — | Module docstring: which key family each consumer may read |
+| NFC-e endpoints | 49-363 | `NFCE` | NFC-e webservice URLs, QR Code URLs and consultation URLs by state |
+| `qrcode_host` helper | 366-384 | — | Consultation-portal host prefix for `<qrCode>` |
+| `url_consulta_chave` helper | 392-406 | — | Complete `<urlChave>` URL, never concatenated |
+| NF-e endpoints | 412-583 | `NFE` | NF-e webservice URLs by state |
+| NFS-e endpoints | 586-611 | `NFSE` | NFS-e URLs (Betha, Ginfes) |
+| MDF-e endpoints | 614-628 | `MDFE` | MDF-e URLs (SVRS only) |
+| CT-e endpoints | 630-684 | `CTE` | CT-e URLs by state |
 
 ## URL Structure
 
@@ -42,48 +42,52 @@ The two host families must never be shared: a UF such as GO answers webservice P
 its consultation host with a load-balancer redirect and HTML, so the invoice never receives a
 SEFAZ verdict and the failure surfaces as a transport/XML-parse error, not a rejeicao.
 
-`<qrCode>` and `<urlChave>` are likewise separate registries — no UF uses the QR Code address
-as its consultation-by-key address. GO rejects 878 when they are the same. `urlChave` values
-live in `CONSULTA_CHAVE*`; `qrCode` is built from `QR*` over `qrcode_host`.
+`<qrCode>` and `<urlChave>` are likewise separate registries, each with its own entry in the
+official listing, so one is never a safe substitute for the other: GO rejects 878 when
+`urlChave` carries the QR Code address. Equality is not by itself the defect — the registry
+does list the same address for both fields in a few UFs (SC today) — so always compare against
+the registry entry for the field you are changing, never against the sibling field. `urlChave`
+values live in `CONSULTA_CHAVE*`; `qrCode` is built from `QR*` over `qrcode_host`. The exact set
+of UFs where the two addresses coincide is pinned in `tests/test_nfce_urlchave_por_uf.py`.
 
 ## State/Virtual Environment Groups
 
-### NFC-e (`NFCE`) — Lines 24-323
+### NFC-e (`NFCE`) — Lines 49-363
 | Key | Lines | Description |
 |-----|-------|-------------|
-| Individual states | 25-311 | RO, AC, AM, RR, PA, AP, TO, MA, PI, CE, RN, PB, PE, AL, SE, BA, MG, ES, RJ, SP, PR, SC, RS, MS, MT, GO, DF |
-| `SVRS` | 312-322 | Virtual SEFAZ RS (fallback for states without own NFC-e) |
+| Individual states | 50-350 | RO, AC, AM, RR, PA, AP, TO, MA, PI, CE, RN, PB, PE, AL, SE, BA, MG, ES, RJ, SP, PR, SC, RS, MS, MT, GO, DF |
+| `SVRS` | 352-362 | Virtual SEFAZ RS (fallback for states without own NFC-e) |
 
-### NF-e (`NFE`) — Lines 343-514
+### NF-e (`NFE`) — Lines 412-583
 | Key | Lines | Description |
 |-----|-------|-------------|
-| `AN` | 345-352 | National environment (events, distribution) |
-| Individual states | 353-472 | AM, MA, PE, BA, MG, SP, PR, RS, MS, MT, GO |
-| `SVAN` | 473-483 | Virtual SEFAZ AN (MA for NF-e) |
-| `SVRS` | 484-494 | Virtual SEFAZ RS (most states) |
-| `SVC-AN` | 495-503 | Contingency AN |
-| `SVC-RS` | 504-513 | Contingency RS |
+| `AN` | 414-421 | National environment (events, distribution) |
+| Individual states | 422-541 | AM, MA, PE, BA, MG, SP, PR, RS, MS, MT, GO |
+| `SVAN` | 542-552 | Virtual SEFAZ AN (MA for NF-e) |
+| `SVRS` | 553-563 | Virtual SEFAZ RS (most states) |
+| `SVC-AN` | 564-572 | Contingency AN |
+| `SVC-RS` | 573-582 | Contingency RS |
 
-### NFS-e (`NFSE`) — Lines 517-542
+### NFS-e (`NFSE`) — Lines 586-611
 | Key | Lines | Description |
 |-----|-------|-------------|
-| `BETHA` | 519-530 | Betha provider (HTTP WSDL) |
-| `GINFES` | 531-541 | Ginfes provider (HTTPS WSDL) |
+| `BETHA` | 588-598 | Betha provider (HTTP WSDL) |
+| `GINFES` | 600-610 | Ginfes provider (HTTPS WSDL) |
 
-### MDF-e (`MDFE`) — Lines 545-559
-Only `SVRS` (547-558) — single authorizer for all states.
+### MDF-e (`MDFE`) — Lines 614-628
+Only `SVRS` (616-627) — single authorizer for all states.
 
-### CT-e (`CTE`) — Lines 561-615
+### CT-e (`CTE`) — Lines 630-684
 | Key | Lines | Description |
 |-----|-------|-------------|
-| `AN` | 562-566 | National environment (distribution) |
-| Individual states | 567-602 | MT, MS, MG, PR, RS, SP |
-| `SVRS` | 603-608 | Virtual SEFAZ RS |
-| `SVSP` | 609-614 | Virtual SEFAZ SP (AP, PE, RR) |
+| `AN` | 631-635 | National environment (distribution) |
+| Individual states | 636-671 | MT, MS, MG, PR, RS, SP |
+| `SVRS` | 672-677 | Virtual SEFAZ RS |
+| `SVSP` | 678-683 | Virtual SEFAZ SP (AP, PE, RR) |
 
 ## Helpers
 
 | Function | Lines | Purpose |
 |----------|-------|---------|
-| `qrcode_host(uf, producao=True)` | 362-375 | Consultation-portal host prefix for `<qrCode>`, with fallback to the webservice host |
-| `url_consulta_chave(uf, producao=True)` | 378-399 | Complete `<urlChave>` URL from `CONSULTA_CHAVE*`, falling back to the legacy `URL` path |
+| `qrcode_host(uf, producao=True)` | 366-384 | Consultation-portal host prefix for `<qrCode>`, with fallback to the webservice host |
+| `url_consulta_chave(uf, producao=True)` | 392-406 | Complete `<urlChave>` URL from `CONSULTA_CHAVE*`, falling back to the legacy `URL` path (which it prefixes with `qrcode_host`) |

--- a/pynfe/utils/webservices.py
+++ b/pynfe/utils/webservices.py
@@ -19,8 +19,8 @@ consulta de uma UF, mexa somente nas chaves ``QR_*``.
 
 ``qrCode`` vs ``urlChave``
 -------------------------
-Sao dois campos do ``<infNFeSupl>`` com registros oficiais DIFERENTES, e nenhuma UF
-usa o mesmo endereco nos dois:
+Sao dois campos do ``<infNFeSupl>`` com registros oficiais DIFERENTES, cada um lido da
+sua propria entrada - nunca do campo irmao:
 
 - ``<qrCode>``: endereco do leitor de QR Code (``QR``/``QR_HOMOLOGACAO`` sobre
   ``qrcode_host``).
@@ -36,7 +36,11 @@ nas UFs que ainda dependem do caminho legado ``URL``. Ao registrar uma UF nova,
 declare ``CONSULTA_CHAVE`` em vez de mexer em ``URL``.
 
 Usar o endereco de QR Code no ``urlChave`` gera rejeicao 878 em GO ("Endereco do site
-da UF da Consulta por chave de acesso diverge do previsto") - DEV-2468.
+da UF da Consulta por chave de acesso diverge do previsto") - DEV-2468. A igualdade entre
+os dois campos nao e por si um defeito: em algumas UFs o registro oficial declara o mesmo
+endereco nos dois (SC hoje). O conjunto fechado dessas UFs esta travado em
+``tests/test_nfce_urlchave_por_uf.py``; compare sempre com a entrada do registro do campo
+que voce esta mexendo.
 """
 
 # http://nfce.encat.org/desenvolvedor/qrcode/
@@ -366,8 +370,12 @@ def qrcode_host(uf, producao=True):
     declaram host de consulta proprio (portal e autorizador no mesmo servidor), cai no
     host de webservice, preservando o comportamento historico.
 
-    Nao serve o ``<urlChave>``: esse campo tem registro proprio e URL completa, ver
-    ``url_consulta_chave``.
+    Uma UF com ``CONSULTA_CHAVE`` nunca passa por aqui para montar o ``<urlChave>`` -
+    esse campo tem registro proprio e URL completa, ver ``url_consulta_chave``. So o
+    caminho legado (UF sem ``CONSULTA_CHAVE``) ainda concatena este prefixo sobre ``URL``,
+    e e por isso que corrigir ``HTTPS``/``HOMOLOGACAO`` de uma dessas UFs move tambem o
+    ``urlChave`` dela: declare ``QR_HOST``/``QR_HOST_HOMOLOGACAO`` antes de mexer no host
+    de autorizador, como foi feito em AM e SP.
     """
     dados = NFCE[uf]
     chave_qr = "QR_HOST" if producao else "QR_HOST_HOMOLOGACAO"


### PR DESCRIPTION
## Contexto

Revisao adversarial da rodada DEV-2468 (PRs #8, #9 e #10, todas mergeadas). Reproduzi a
verificacao inteira e re-derivei o comportamento antes/depois de `<qrCode>` e `<urlChave>`
para as 29 chaves de `NFCE`, nos dois ambientes, executando a implementacao antiga
(`git show b613366~1:pynfe/utils/webservices.py`) contra a atual.

**Resultado da revisao de comportamento: nenhuma regressao.** As unicas saidas que mudam em
toda a tabela sao as tres pretendidas — `urlChave` de GO (producao e homologacao) e de BA
(producao). Todas as outras UFs saem byte-identicas, incluindo os casos que a refatoracao
poderia ter arrastado sem ninguem notar: SP e AM (que montavam o host de QR a partir da
chave de webservice, e cujo `HTTPS` mudou nesta mesma rodada), MG e BA (que tinham ramo
proprio no `gerar_qrcode`) e RJ/DF (que emitem `urlChave` sem esquema).

Este PR nao muda comportamento. Corrige tres defeitos de documentacao que a propria rodada
introduziu, dois deles capazes de causar regressao fiscal na mao do proximo agente.

## 1. Regra falsa: "nenhuma UF usa o mesmo endereco nos dois campos"

Afirmada em tres lugares — `AGENTS.md`, docstring de `pynfe/utils/webservices.py` e
`docs/webservices_map.md` — e contradita pelo teste da mesma rodada:

```python
# tests/test_nfce_urlchave_por_uf.py
# UFs em que o registro oficial usa o MESMO endereco para consulta e QR Code (SC: o proprio
# ACBr registra sat.sef.sc.gov.br/nfce/consulta nos dois) ...
UFS_URLCHAVE_IGUAL_AO_QRCODE = frozenset({"RS", "SC"})
```

O control file da rodada diz o mesmo com todas as letras: *"`urlChave` != `qrCode` para toda
UF" e falso como regra geral*. Uma regra em `AGENTS.md` e lida por todo agente em toda task
neste repo; como estava, mandava "corrigir" SC — que os testes travam byte-identico contra o
registro do ACBr. Reescrita para a regra que de fato vale: **cada campo vem da sua propria
entrada do registro, nunca do campo irmao nem de UF vizinha**; igualdade nao e por si defeito,
e o conjunto de UFs onde os enderecos coincidem esta travado no teste.

## 2. `qrcode_host` afirma nao servir o `urlChave`, mas serve

```python
Nao serve o ``<urlChave>``: esse campo tem registro proprio e URL completa, ver
``url_consulta_chave``.
```

`url_consulta_chave` chama `qrcode_host` no caminho legado, 30 linhas abaixo:

```python
    if uf in UFS_URLCHAVE_SEM_HOST:
        return dados["URL"]
    return qrcode_host(uf, producao=producao) + dados["URL"]
```

Isso importa porque e exatamente o acoplamento que obrigou esta rodada a declarar `QR_HOST` em
AM: sem ele, mudar `NFCE["AM"]["HTTPS"]` de `https://sistemas.` para `https://` teria movido o
`urlChave` de AM junto com o host de autorizador. A docstring agora descreve o acoplamento e
diz o que fazer antes de mexer no host de autorizador de uma UF que ainda depende do legado.

## 3. Source maps errados e contraditorios entre si

`AGENTS.md` torna a leitura do `_map.md` **obrigatoria** antes de abrir arquivo grande, para
ler so a janela de linhas indicada — numero errado manda o proximo agente para a janela errada.

| Onde | Dizia | Real |
|---|---|---|
| `AGENTS.md`, `serializacao.py` | 2895 linhas | 2881 |
| `AGENTS.md`, `webservices.py` | 615 linhas | 684 |
| `serializacao_map.md`, `SerializacaoNfse` | 2326-2392 (sobrepondo `SerializacaoQrcodeMDFe`) | 2312-2378 |
| `webservices_map.md`, cabecalho | 673 linhas | 684 |
| `webservices_map.md`, secao `NFCE` | 24-323 (a tabela de sumario do mesmo arquivo dizia 45-359) | 49-363 |
| `webservices_map.md`, secao `NFE` | 343-514 | 412-583 |

As faixas de `NFSE`, `MDFE`, `CTE`, dos sub-blocos (`AN`, `SVAN`, `SVRS`, `SVC-*`, `SVSP`,
`BETHA`, `GINFES`) e das duas helpers estavam deslocadas do mesmo jeito. Todas recalculadas do
arquivo, ja incluindo o deslocamento causado pelas docstrings deste PR.

## Verificacao

Reproduzida por mim neste worktree, comandos verbatim do `AGENTS.md`:

- `python3 -m pytest tests/` → `184 passed`
- `python3 -m ruff check pynfe/` → `All checks passed!`
- `python3 -m ruff format --check pynfe/` → `49 files already formatted`

Nenhum type checker esta configurado neste repo (nada em `pyproject.toml` nem no `AGENTS.md`).
